### PR TITLE
Add Sorbian locale templates with German content

### DIFF
--- a/config/locales/activerecord.dsb.yml
+++ b/config/locales/activerecord.dsb.yml
@@ -1,0 +1,77 @@
+---
+dsb:
+  activerecord:
+    attributes:
+      poll:
+        expires_at: Abstimmungsende
+        options: Auswahlmöglichkeiten
+      user:
+        agreement: Service-Vereinbarung
+        email: E-Mail-Adresse
+        locale: Sprache
+        password: Passwort
+      user/account:
+        username: Profilname
+      user/invite_request:
+        text: Begründung
+    errors:
+      attributes:
+        domain:
+          invalid: ist kein gültiger Domain-Name
+      messages:
+        invalid_domain_on_line: "%{value} ist kein gültiger Domain-Name"
+      models:
+        account:
+          attributes:
+            fields:
+              fields_with_values_missing_labels: enthält Werte, bei denen Beschriftungen fehlen
+            username:
+              invalid: nur Buchstaben, Ziffern und Unterstriche
+              reserved: ist bereits vergeben
+        admin/webhook:
+          attributes:
+            url:
+              invalid: ist keine gültige URL
+        doorkeeper/application:
+          attributes:
+            website:
+              invalid: ist keine gültige URL
+        import:
+          attributes:
+            data:
+              malformed: ist fehlerhaft
+        list_account:
+          attributes:
+            account_id:
+              taken: befindet sich bereits auf der Liste
+          must_be_following: muss ein gefolgtes Konto sein
+        status:
+          attributes:
+            reblog:
+              taken: des Beitrags existiert bereits
+        terms_of_service:
+          attributes:
+            effective_date:
+              too_soon: Datum muss später als %{date} sein
+        user:
+          attributes:
+            date_of_birth:
+              below_limit: liegt unterhalb der Altersgrenze
+            email:
+              blocked: verwendet einen unerlaubten E-Mail-Anbieter
+              unreachable: scheint nicht zu existieren
+            role_id:
+              elevated: kann nicht höher als deine derzeitige Rolle sein
+        user_role:
+          attributes:
+            permissions_as_keys:
+              dangerous: enthält Berechtigungen, die für die Basisrolle nicht sicher sind
+              elevated: kann keine Berechtigungen enthalten, die deine aktuelle Rolle nicht besitzt
+              own_role: kann mit deiner aktuellen Rolle nicht geändert werden
+            position:
+              elevated: darf nicht höher als deine derzeitige Rolle sein
+              own_role: darf nicht mit deiner aktuellen Rolle geändert werden
+        webhook:
+          attributes:
+            events:
+              invalid_permissions: kann keine Ereignisse einschließen, für die du keine Berechtigung hast

--- a/config/locales/activerecord.hsb.yml
+++ b/config/locales/activerecord.hsb.yml
@@ -1,0 +1,77 @@
+---
+hsb:
+  activerecord:
+    attributes:
+      poll:
+        expires_at: Abstimmungsende
+        options: Auswahlmöglichkeiten
+      user:
+        agreement: Service-Vereinbarung
+        email: E-Mail-Adresse
+        locale: Sprache
+        password: Passwort
+      user/account:
+        username: Profilname
+      user/invite_request:
+        text: Begründung
+    errors:
+      attributes:
+        domain:
+          invalid: ist kein gültiger Domain-Name
+      messages:
+        invalid_domain_on_line: "%{value} ist kein gültiger Domain-Name"
+      models:
+        account:
+          attributes:
+            fields:
+              fields_with_values_missing_labels: enthält Werte, bei denen Beschriftungen fehlen
+            username:
+              invalid: nur Buchstaben, Ziffern und Unterstriche
+              reserved: ist bereits vergeben
+        admin/webhook:
+          attributes:
+            url:
+              invalid: ist keine gültige URL
+        doorkeeper/application:
+          attributes:
+            website:
+              invalid: ist keine gültige URL
+        import:
+          attributes:
+            data:
+              malformed: ist fehlerhaft
+        list_account:
+          attributes:
+            account_id:
+              taken: befindet sich bereits auf der Liste
+          must_be_following: muss ein gefolgtes Konto sein
+        status:
+          attributes:
+            reblog:
+              taken: des Beitrags existiert bereits
+        terms_of_service:
+          attributes:
+            effective_date:
+              too_soon: Datum muss später als %{date} sein
+        user:
+          attributes:
+            date_of_birth:
+              below_limit: liegt unterhalb der Altersgrenze
+            email:
+              blocked: verwendet einen unerlaubten E-Mail-Anbieter
+              unreachable: scheint nicht zu existieren
+            role_id:
+              elevated: kann nicht höher als deine derzeitige Rolle sein
+        user_role:
+          attributes:
+            permissions_as_keys:
+              dangerous: enthält Berechtigungen, die für die Basisrolle nicht sicher sind
+              elevated: kann keine Berechtigungen enthalten, die deine aktuelle Rolle nicht besitzt
+              own_role: kann mit deiner aktuellen Rolle nicht geändert werden
+            position:
+              elevated: darf nicht höher als deine derzeitige Rolle sein
+              own_role: darf nicht mit deiner aktuellen Rolle geändert werden
+        webhook:
+          attributes:
+            events:
+              invalid_permissions: kann keine Ereignisse einschließen, für die du keine Berechtigung hast

--- a/config/locales/devise.dsb.yml
+++ b/config/locales/devise.dsb.yml
@@ -1,0 +1,116 @@
+---
+dsb:
+  devise:
+    confirmations:
+      confirmed: Deine E-Mail-Adresse wurde erfolgreich bestätigt.
+      send_instructions: Du wirst in wenigen Minuten eine E-Mail erhalten. Darin wird erklärt, wie du deine E-Mail-Adresse bestätigen kannst. Schau bitte auch in deinem Spam-Ordner nach, wenn du diese E-Mail nicht erhalten hast.
+      send_paranoid_instructions: Falls deine E-Mail-Adresse in unserer Datenbank hinterlegt ist, wirst du in wenigen Minuten eine E-Mail erhalten. Darin wird erklärt, wie du deine E-Mail-Adresse bestätigen kannst. Schau bitte auch in deinem Spam-Ordner nach, wenn du diese E-Mail nicht erhalten hast.
+    failure:
+      already_authenticated: Du bist bereits angemeldet.
+      inactive: Dein Konto wurde noch nicht aktiviert.
+      invalid: "%{authentication_keys} oder Passwort ungültig."
+      last_attempt: Du hast nur noch einen Versuch, bevor dein Zugang gesperrt wird.
+      locked: Dein Konto ist gesperrt.
+      not_found_in_database: "%{authentication_keys} oder Passwort ungültig."
+      omniauth_user_creation_failure: Fehler beim Erstellen eines Kontos für diese Identität.
+      pending: Dein Konto wird weiterhin überprüft.
+      timeout: Deine Sitzung ist abgelaufen. Bitte melde dich erneut an, um fortzufahren.
+      unauthenticated: Du musst dich anmelden oder registrieren, bevor du fortfahren kannst.
+      unconfirmed: Du musst deine E-Mail-Adresse bestätigen, bevor du fortfahren kannst.
+    mailer:
+      confirmation_instructions:
+        action: E-Mail-Adresse verifizieren
+        action_with_app: Bestätigen – und dann zur App %{app} zurückkehren
+        explanation: Du hast mit dieser E-Mail-Adresse ein Konto auf %{host} erstellt. Du bist nur noch einen Klick von der Aktivierung entfernt. Wenn du das nicht warst, dann kannst du diese E-Mail ignorieren.
+        explanation_when_pending: Du hast dich für eine Einladung bei %{host} mit dieser E-Mail-Adresse beworben. Sobald du deine E-Mail-Adresse bestätigt hast, werden wir deine Anfrage überprüfen. Du kannst dich in dieser Zeit nicht anmelden. Wenn deine Anfrage abgelehnt wird, werden deine Daten entfernt – von dir ist keine weitere Handlung notwendig. Wenn du das nicht warst, dann kannst du diese E-Mail ignorieren.
+        extra_html: Bitte beachte auch die <a href="%{terms_path}">Serverregeln</a> und <a href="%{policy_path}">unsere Datenschutzerklärung</a>.
+        subject: 'Mastodon: Anleitung zum Bestätigen deines Kontos auf %{instance}'
+        title: Verifiziere deine E-Mail-Adresse
+      email_changed:
+        explanation: 'Die E-Mail-Adresse deines Kontos wird geändert zu:'
+        extra: Wenn du deine E-Mail-Adresse nicht geändert hast, ist es wahrscheinlich, dass sich jemand Zugang zu deinem Konto verschafft hat. Bitte ändere sofort dein Passwort oder kontaktiere die Administrator*innen des Servers, wenn du aus deinem Konto ausgesperrt bist.
+        subject: 'Mastodon: E-Mail-Adresse geändert'
+        title: Neue E-Mail-Adresse
+      password_change:
+        explanation: Das Passwort für dein Konto wurde geändert.
+        extra: Wenn du dein Passwort nicht geändert hast, ist es wahrscheinlich, dass sich jemand Zugang zu deinem Konto verschafft hat. Bitte ändere sofort dein Passwort oder kontaktiere die Administrator*innen des Servers, wenn du aus deinem Konto ausgesperrt bist.
+        subject: 'Mastodon: Passwort geändert'
+        title: Passwort geändert
+      reconfirmation_instructions:
+        explanation: Bestätige deine neue E-Mail-Adresse, um sie zu ändern.
+        extra: Wenn diese Änderung nicht von dir ausgeführt wurde, dann kannst du diese E-Mail ignorieren. Die E-Mail-Adresse für dein Mastodon-Konto wird sich erst ändern, wenn du den obigen Link anklickst.
+        subject: 'Mastodon: E-Mail-Adresse für %{instance} bestätigen'
+        title: E-Mail-Adresse verifizieren
+      reset_password_instructions:
+        action: Passwort ändern
+        explanation: Du hast ein neues Passwort für dein Konto angefordert.
+        extra: Wenn du diese Anfrage nicht gestellt hast, dann kannst du diese E-Mail ignorieren. Dein Passwort wird sich erst ändern, wenn du den obigen Link anklickst und ein neues Passwort erstellst.
+        subject: 'Mastodon: Anleitung zum Zurücksetzen deines Passworts'
+        title: Passwort zurücksetzen
+      two_factor_disabled:
+        explanation: Das Anmelden ist jetzt nur noch mit einer E-Mail-Adresse und einem Passwort möglich.
+        subject: 'Mastodon: Zwei‐Faktor‐Authentisierung deaktiviert'
+        subtitle: Zwei-Faktor-Authentisierung wurde für dein Konto deaktiviert.
+        title: 2FA deaktiviert
+      two_factor_enabled:
+        explanation: Für das Anmelden wird ein Token benötigt, das von der hinterlegten TOTP-App generiert wird.
+        subject: 'Mastodon: Zwei‐Faktor‐Authentisierung aktiviert'
+        subtitle: Zwei-Faktor-Authentisierung wurde für dein Konto aktiviert.
+        title: 2FA aktiviert
+      two_factor_recovery_codes_changed:
+        explanation: Die vorherigen Wiederherstellungscodes wurden ungültig gemacht und es wurden neue erstellt.
+        subject: 'Mastodon: Zwei-Faktor-Wiederherstellungscodes neu erstellt'
+        subtitle: Die vorherigen Wiederherstellungscodes wurden ungültig gemacht und es wurden neue erstellt.
+        title: 2FA-Wiederherstellungscodes geändert
+      unlock_instructions:
+        subject: 'Mastodon: Anleitung zum Entsperren deines Kontos'
+      webauthn_credential:
+        added:
+          explanation: Der folgende Sicherheitsschlüssel wurde zu deinem Konto hinzugefügt
+          subject: 'Mastodon: Neuer Sicherheitsschlüssel'
+          title: Ein neuer Sicherheitsschlüssel wurde hinzugefügt
+        deleted:
+          explanation: Der folgende Sicherheitsschlüssel wurde von deinem Konto entfernt
+          subject: 'Mastodon: Sicherheitsschlüssel entfernt'
+          title: Einer deiner Sicherheitsschlüssel wurde entfernt
+      webauthn_disabled:
+        explanation: Die Authentisierung mit Sicherheitsschlüsseln wurde für dein Konto deaktiviert.
+        extra: Das Anmelden ist jetzt nur noch mit Token aus der TOTP-App möglich, die im Konto hinterlegt wurde.
+        subject: 'Mastodon: Authentisierung mit Sicherheitsschlüsseln deaktiviert'
+        title: Sicherheitsschlüssel deaktiviert
+      webauthn_enabled:
+        explanation: Die Authentisierung mit Sicherheitsschlüsseln wurde für dein Konto aktiviert.
+        extra: Dein Sicherheitsschlüssel kann jetzt zum Anmelden verwendet werden.
+        subject: 'Mastodon: Authentisierung mit Sicherheitsschlüssel aktiviert'
+        title: Sicherheitsschlüssel aktiviert
+    omniauth_callbacks:
+      failure: Du konntest nicht mit deinem %{kind}-Konto angemeldet werden, weil „%{reason}“.
+      success: Du hast dich erfolgreich mit deinem Konto %{kind} angemeldet.
+    passwords:
+      no_token: Du kannst diese Seite nur über den Link aus der E-Mail zum Zurücksetzen des Passworts aufrufen. Wenn du einen solchen Link aufgerufen hast, vergewissere dich bitte, dass du die vollständige Adresse aufrufst.
+      send_instructions: Du erhältst in wenigen Minuten eine E-Mail, sofern deine Adresse unserer Datenbank bekannt ist. In dieser Nachricht befindet sich ein Link. Wenn du diesen aufrufst, kannst du dein Passwort zurücksetzen. Sollte die E-Mail nicht im Posteingangsordner landen, überprüfe auch deinen Spam-/Junk-Ordner.
+      send_paranoid_instructions: Du erhältst in wenigen Minuten eine E-Mail, sofern deine Adresse unserer Datenbank bekannt ist. In dieser Nachricht befindet sich ein Link. Wenn du diesen aufrufst, kannst du dein Passwort zurücksetzen. Sollte die E-Mail nicht im Posteingangsordner landen, überprüfe auch deinen Spam-/Junk-Ordner.
+      updated: Dein Passwort wurde erfolgreich geändert. Du bist jetzt angemeldet.
+      updated_not_active: Dein Passwort wurde erfolgreich geändert.
+    registrations:
+      destroyed: Tschüss! Dein Konto wurde erfolgreich gelöscht. Wir hoffen, dich bald wiederzusehen.
+      update_needs_confirmation: Deine Daten wurden aktualisiert, aber du musst deine neue E-Mail-Adresse bestätigen. Du erhältst in wenigen Minuten eine E-Mail. Darin ist erklärt, wie du die Änderung deiner E-Mail-Adresse abschließen kannst.
+      updated: Dein Konto wurde erfolgreich aktualisiert.
+    sessions:
+      already_signed_out: Erfolgreich abgemeldet.
+      signed_in: Erfolgreich angemeldet.
+      signed_out: Erfolgreich abgemeldet.
+    unlocks:
+      send_instructions: Du erhältst in wenigen Minuten eine E-Mail. Darin wird erklärt, wie du dein Konto entsperren kannst. Sollte die E-Mail nicht im Posteingangsordner landen, überprüfe auch deinen Spam-/Junk-Ordner.
+      send_paranoid_instructions: Falls deine E-Mail-Adresse in unserer Datenbank hinterlegt ist, erhältst du in wenigen Minuten eine E-Mail. Darin wird erklärt, wie du dein Konto entsperren kannst. Sollte die E-Mail nicht im Posteingangsordner landen, überprüfe auch deinen Spam-/Junk-Ordner.
+      unlocked: Dein Konto wurde erfolgreich entsperrt. Bitte melde dich an, um fortzufahren.
+  errors:
+    messages:
+      already_confirmed: wurde bereits bestätigt, bitte versuche dich anzumelden
+      confirmation_period_expired: muss innerhalb %{period} bestätigt werden, bitte fordere einen neuen Link an
+      expired: ist abgelaufen, bitte neu anfordern
+      not_found: nicht gefunden
+      not_locked: ist nicht gesperrt
+      not_saved:
+        one: '1 Fehler verhinderte, dass %{resource} gespeichert wurde:'
+        other: "%{count} Fehler verhinderten, dass %{resource} gespeichert wurde:"

--- a/config/locales/devise.hsb.yml
+++ b/config/locales/devise.hsb.yml
@@ -1,0 +1,116 @@
+---
+hsb:
+  devise:
+    confirmations:
+      confirmed: Deine E-Mail-Adresse wurde erfolgreich bestätigt.
+      send_instructions: Du wirst in wenigen Minuten eine E-Mail erhalten. Darin wird erklärt, wie du deine E-Mail-Adresse bestätigen kannst. Schau bitte auch in deinem Spam-Ordner nach, wenn du diese E-Mail nicht erhalten hast.
+      send_paranoid_instructions: Falls deine E-Mail-Adresse in unserer Datenbank hinterlegt ist, wirst du in wenigen Minuten eine E-Mail erhalten. Darin wird erklärt, wie du deine E-Mail-Adresse bestätigen kannst. Schau bitte auch in deinem Spam-Ordner nach, wenn du diese E-Mail nicht erhalten hast.
+    failure:
+      already_authenticated: Du bist bereits angemeldet.
+      inactive: Dein Konto wurde noch nicht aktiviert.
+      invalid: "%{authentication_keys} oder Passwort ungültig."
+      last_attempt: Du hast nur noch einen Versuch, bevor dein Zugang gesperrt wird.
+      locked: Dein Konto ist gesperrt.
+      not_found_in_database: "%{authentication_keys} oder Passwort ungültig."
+      omniauth_user_creation_failure: Fehler beim Erstellen eines Kontos für diese Identität.
+      pending: Dein Konto wird weiterhin überprüft.
+      timeout: Deine Sitzung ist abgelaufen. Bitte melde dich erneut an, um fortzufahren.
+      unauthenticated: Du musst dich anmelden oder registrieren, bevor du fortfahren kannst.
+      unconfirmed: Du musst deine E-Mail-Adresse bestätigen, bevor du fortfahren kannst.
+    mailer:
+      confirmation_instructions:
+        action: E-Mail-Adresse verifizieren
+        action_with_app: Bestätigen – und dann zur App %{app} zurückkehren
+        explanation: Du hast mit dieser E-Mail-Adresse ein Konto auf %{host} erstellt. Du bist nur noch einen Klick von der Aktivierung entfernt. Wenn du das nicht warst, dann kannst du diese E-Mail ignorieren.
+        explanation_when_pending: Du hast dich für eine Einladung bei %{host} mit dieser E-Mail-Adresse beworben. Sobald du deine E-Mail-Adresse bestätigt hast, werden wir deine Anfrage überprüfen. Du kannst dich in dieser Zeit nicht anmelden. Wenn deine Anfrage abgelehnt wird, werden deine Daten entfernt – von dir ist keine weitere Handlung notwendig. Wenn du das nicht warst, dann kannst du diese E-Mail ignorieren.
+        extra_html: Bitte beachte auch die <a href="%{terms_path}">Serverregeln</a> und <a href="%{policy_path}">unsere Datenschutzerklärung</a>.
+        subject: 'Mastodon: Anleitung zum Bestätigen deines Kontos auf %{instance}'
+        title: Verifiziere deine E-Mail-Adresse
+      email_changed:
+        explanation: 'Die E-Mail-Adresse deines Kontos wird geändert zu:'
+        extra: Wenn du deine E-Mail-Adresse nicht geändert hast, ist es wahrscheinlich, dass sich jemand Zugang zu deinem Konto verschafft hat. Bitte ändere sofort dein Passwort oder kontaktiere die Administrator*innen des Servers, wenn du aus deinem Konto ausgesperrt bist.
+        subject: 'Mastodon: E-Mail-Adresse geändert'
+        title: Neue E-Mail-Adresse
+      password_change:
+        explanation: Das Passwort für dein Konto wurde geändert.
+        extra: Wenn du dein Passwort nicht geändert hast, ist es wahrscheinlich, dass sich jemand Zugang zu deinem Konto verschafft hat. Bitte ändere sofort dein Passwort oder kontaktiere die Administrator*innen des Servers, wenn du aus deinem Konto ausgesperrt bist.
+        subject: 'Mastodon: Passwort geändert'
+        title: Passwort geändert
+      reconfirmation_instructions:
+        explanation: Bestätige deine neue E-Mail-Adresse, um sie zu ändern.
+        extra: Wenn diese Änderung nicht von dir ausgeführt wurde, dann kannst du diese E-Mail ignorieren. Die E-Mail-Adresse für dein Mastodon-Konto wird sich erst ändern, wenn du den obigen Link anklickst.
+        subject: 'Mastodon: E-Mail-Adresse für %{instance} bestätigen'
+        title: E-Mail-Adresse verifizieren
+      reset_password_instructions:
+        action: Passwort ändern
+        explanation: Du hast ein neues Passwort für dein Konto angefordert.
+        extra: Wenn du diese Anfrage nicht gestellt hast, dann kannst du diese E-Mail ignorieren. Dein Passwort wird sich erst ändern, wenn du den obigen Link anklickst und ein neues Passwort erstellst.
+        subject: 'Mastodon: Anleitung zum Zurücksetzen deines Passworts'
+        title: Passwort zurücksetzen
+      two_factor_disabled:
+        explanation: Das Anmelden ist jetzt nur noch mit einer E-Mail-Adresse und einem Passwort möglich.
+        subject: 'Mastodon: Zwei‐Faktor‐Authentisierung deaktiviert'
+        subtitle: Zwei-Faktor-Authentisierung wurde für dein Konto deaktiviert.
+        title: 2FA deaktiviert
+      two_factor_enabled:
+        explanation: Für das Anmelden wird ein Token benötigt, das von der hinterlegten TOTP-App generiert wird.
+        subject: 'Mastodon: Zwei‐Faktor‐Authentisierung aktiviert'
+        subtitle: Zwei-Faktor-Authentisierung wurde für dein Konto aktiviert.
+        title: 2FA aktiviert
+      two_factor_recovery_codes_changed:
+        explanation: Die vorherigen Wiederherstellungscodes wurden ungültig gemacht und es wurden neue erstellt.
+        subject: 'Mastodon: Zwei-Faktor-Wiederherstellungscodes neu erstellt'
+        subtitle: Die vorherigen Wiederherstellungscodes wurden ungültig gemacht und es wurden neue erstellt.
+        title: 2FA-Wiederherstellungscodes geändert
+      unlock_instructions:
+        subject: 'Mastodon: Anleitung zum Entsperren deines Kontos'
+      webauthn_credential:
+        added:
+          explanation: Der folgende Sicherheitsschlüssel wurde zu deinem Konto hinzugefügt
+          subject: 'Mastodon: Neuer Sicherheitsschlüssel'
+          title: Ein neuer Sicherheitsschlüssel wurde hinzugefügt
+        deleted:
+          explanation: Der folgende Sicherheitsschlüssel wurde von deinem Konto entfernt
+          subject: 'Mastodon: Sicherheitsschlüssel entfernt'
+          title: Einer deiner Sicherheitsschlüssel wurde entfernt
+      webauthn_disabled:
+        explanation: Die Authentisierung mit Sicherheitsschlüsseln wurde für dein Konto deaktiviert.
+        extra: Das Anmelden ist jetzt nur noch mit Token aus der TOTP-App möglich, die im Konto hinterlegt wurde.
+        subject: 'Mastodon: Authentisierung mit Sicherheitsschlüsseln deaktiviert'
+        title: Sicherheitsschlüssel deaktiviert
+      webauthn_enabled:
+        explanation: Die Authentisierung mit Sicherheitsschlüsseln wurde für dein Konto aktiviert.
+        extra: Dein Sicherheitsschlüssel kann jetzt zum Anmelden verwendet werden.
+        subject: 'Mastodon: Authentisierung mit Sicherheitsschlüssel aktiviert'
+        title: Sicherheitsschlüssel aktiviert
+    omniauth_callbacks:
+      failure: Du konntest nicht mit deinem %{kind}-Konto angemeldet werden, weil „%{reason}“.
+      success: Du hast dich erfolgreich mit deinem Konto %{kind} angemeldet.
+    passwords:
+      no_token: Du kannst diese Seite nur über den Link aus der E-Mail zum Zurücksetzen des Passworts aufrufen. Wenn du einen solchen Link aufgerufen hast, vergewissere dich bitte, dass du die vollständige Adresse aufrufst.
+      send_instructions: Du erhältst in wenigen Minuten eine E-Mail, sofern deine Adresse unserer Datenbank bekannt ist. In dieser Nachricht befindet sich ein Link. Wenn du diesen aufrufst, kannst du dein Passwort zurücksetzen. Sollte die E-Mail nicht im Posteingangsordner landen, überprüfe auch deinen Spam-/Junk-Ordner.
+      send_paranoid_instructions: Du erhältst in wenigen Minuten eine E-Mail, sofern deine Adresse unserer Datenbank bekannt ist. In dieser Nachricht befindet sich ein Link. Wenn du diesen aufrufst, kannst du dein Passwort zurücksetzen. Sollte die E-Mail nicht im Posteingangsordner landen, überprüfe auch deinen Spam-/Junk-Ordner.
+      updated: Dein Passwort wurde erfolgreich geändert. Du bist jetzt angemeldet.
+      updated_not_active: Dein Passwort wurde erfolgreich geändert.
+    registrations:
+      destroyed: Tschüss! Dein Konto wurde erfolgreich gelöscht. Wir hoffen, dich bald wiederzusehen.
+      update_needs_confirmation: Deine Daten wurden aktualisiert, aber du musst deine neue E-Mail-Adresse bestätigen. Du erhältst in wenigen Minuten eine E-Mail. Darin ist erklärt, wie du die Änderung deiner E-Mail-Adresse abschließen kannst.
+      updated: Dein Konto wurde erfolgreich aktualisiert.
+    sessions:
+      already_signed_out: Erfolgreich abgemeldet.
+      signed_in: Erfolgreich angemeldet.
+      signed_out: Erfolgreich abgemeldet.
+    unlocks:
+      send_instructions: Du erhältst in wenigen Minuten eine E-Mail. Darin wird erklärt, wie du dein Konto entsperren kannst. Sollte die E-Mail nicht im Posteingangsordner landen, überprüfe auch deinen Spam-/Junk-Ordner.
+      send_paranoid_instructions: Falls deine E-Mail-Adresse in unserer Datenbank hinterlegt ist, erhältst du in wenigen Minuten eine E-Mail. Darin wird erklärt, wie du dein Konto entsperren kannst. Sollte die E-Mail nicht im Posteingangsordner landen, überprüfe auch deinen Spam-/Junk-Ordner.
+      unlocked: Dein Konto wurde erfolgreich entsperrt. Bitte melde dich an, um fortzufahren.
+  errors:
+    messages:
+      already_confirmed: wurde bereits bestätigt, bitte versuche dich anzumelden
+      confirmation_period_expired: muss innerhalb %{period} bestätigt werden, bitte fordere einen neuen Link an
+      expired: ist abgelaufen, bitte neu anfordern
+      not_found: nicht gefunden
+      not_locked: ist nicht gesperrt
+      not_saved:
+        one: '1 Fehler verhinderte, dass %{resource} gespeichert wurde:'
+        other: "%{count} Fehler verhinderten, dass %{resource} gespeichert wurde:"

--- a/config/locales/doorkeeper.dsb.yml
+++ b/config/locales/doorkeeper.dsb.yml
@@ -1,0 +1,198 @@
+---
+dsb:
+  activerecord:
+    attributes:
+      doorkeeper/application:
+        name: Anwendungsname
+        redirect_uri: Weiterleitungs-URI
+        scopes: Befugnisse
+        website: Website der Anwendung
+    errors:
+      models:
+        doorkeeper/application:
+          attributes:
+            redirect_uri:
+              fragment_present: darf kein Fragment enthalten.
+              invalid_uri: muss ein valider URI sein.
+              relative_uri: muss ein absoluter URI sein.
+              secured_uri: muss ein HTTPS-/SSL-URI sein.
+  doorkeeper:
+    applications:
+      buttons:
+        authorize: Autorisieren
+        cancel: Abbrechen
+        destroy: Löschen
+        edit: Bearbeiten
+        submit: Speichern
+      confirmations:
+        destroy: Bist du dir sicher?
+      edit:
+        title: Anwendung bearbeiten
+      form:
+        error: Ups! Bitte überprüfe das Formular auf mögliche Fehler
+      help:
+        native_redirect_uri: Verwende %{native_redirect_uri} für lokale Tests
+        redirect_uri: Verwende eine Zeile pro URI
+        scopes: Bitte die Befugnisse mit Leerzeichen trennen. Zur Verwendung der Standardwerte freilassen.
+      index:
+        application: Anwendung
+        callback_url: Callback-URL
+        delete: Löschen
+        empty: Du hast keine Anwendungen.
+        name: Name
+        new: Neue Anwendung
+        scopes: Befugnisse
+        show: Anzeigen
+        title: Deine Anwendungen
+      new:
+        title: Neue Anwendung
+      show:
+        actions: Aktionen
+        application_id: Client-Schlüssel
+        callback_urls: Callback-URLs
+        scopes: Befugnisse
+        secret: Client-Secret
+        title: 'Anwendung: %{name}'
+    authorizations:
+      buttons:
+        authorize: Autorisieren
+        deny: Verweigern
+      error:
+        title: Ein Fehler ist aufgetreten
+      new:
+        prompt_html: "%{client_name} möchte auf dein Konto zugreifen. <strong>Du solltest diese Anfrage nur genehmigen, wenn du diese Quelle kennst und ihr vertraust.</strong>"
+        review_permissions: Berechtigungen überprüfen
+        title: Autorisierung erforderlich
+      show:
+        title: Kopiere diesen Autorisierungs-Code und füge ihn in die Anwendung ein.
+    authorized_applications:
+      buttons:
+        revoke: Widerrufen
+      confirmations:
+        revoke: Bist du dir sicher?
+      index:
+        authorized_at: Autorisiert am %{date}
+        description_html: Dies sind Anwendungen, die über die Programmierschnittstelle (API) auf dein Konto zugreifen können. Wenn es Anwendungen gibt, die du hier nicht zuordnen kannst oder wenn sich eine Anwendung verdächtig verhält, kannst du den Zugriff widerrufen.
+        last_used_at: Zuletzt verwendet am %{date}
+        never_used: Nie verwendet
+        scopes: Berechtigungen
+        superapp: Intern
+        title: Deine autorisierten Anwendungen
+    errors:
+      messages:
+        access_denied: Diese Anfrage wurde von den Inhaber*innen oder durch den Autorisierungsserver abgelehnt.
+        credential_flow_not_configured: Das Konto konnte nicht gefunden werden, da Doorkeeper.configure.resource_owner_from_credentials nicht konfiguriert ist.
+        invalid_client: 'Client-Authentisierung ist fehlgeschlagen: Client unbekannt, keine Authentisierung mitgeliefert oder Authentisierungsmethode wird nicht unterstützt.'
+        invalid_code_challenge_method: Die Code-Challenge-Methode muss „S256“ sein, „plain“ wird nicht unterstützt.
+        invalid_grant: Die beigefügte Autorisierung ist ungültig, abgelaufen, wurde widerrufen oder einem anderen Client ausgestellt, oder der Weiterleitungs-URI stimmt nicht mit der Autorisierungs-Anfrage überein.
+        invalid_redirect_uri: Der beigefügte Weiterleitungs-URI ist ungültig.
+        invalid_request:
+          missing_param: 'Erforderlicher Parameter fehlt: %{value}.'
+          request_not_authorized: Anfrage muss autorisiert werden. Benötigter Parameter für die Autorisierung der Anfrage fehlt oder ungültig.
+          unknown: Der Anfrage fehlt ein benötigter Parameter, enthält einen nicht unterstützten Parameterwert oder ist anderweitig fehlerhaft.
+        invalid_resource_owner: Die angegebenen Zugangsdaten für das Konto sind ungültig, oder das Konto kann nicht gefunden werden
+        invalid_scope: Die angeforderte Befugnis ist ungültig, unbekannt oder fehlerhaft.
+        invalid_token:
+          expired: Der Zugriffstoken ist abgelaufen
+          revoked: Der Zugriffstoken wurde widerrufen
+          unknown: Der Zugriffstoken ist ungültig
+        resource_owner_authenticator_not_configured: Das Konto konnte nicht gefunden werden, da Doorkeeper.configure.resource_owner_authenticator nicht konfiguriert ist.
+        server_error: Der Autorisierungs-Server hat ein unerwartetes Problem festgestellt und konnte die Anfrage nicht bearbeiten.
+        temporarily_unavailable: Der Autorisierungs-Server ist aufgrund von zwischenzeitlicher Überlastung oder Wartungsarbeiten derzeit nicht in der Lage, die Anfrage zu bearbeiten.
+        unauthorized_client: Der Client ist nicht dazu autorisiert, diese Anfrage mit dieser Methode auszuführen.
+        unsupported_grant_type: Der Autorisierungs-Typ wird nicht vom Autorisierungs-Server unterstützt.
+        unsupported_response_type: Der Autorisierungs-Server unterstützt diesen Antwort-Typ nicht.
+    flash:
+      applications:
+        create:
+          notice: Anwendung erstellt.
+        destroy:
+          notice: Anwendung gelöscht.
+        update:
+          notice: Anwendung aktualisiert.
+      authorized_applications:
+        destroy:
+          notice: Anwendung widerrufen.
+    grouped_scopes:
+      access:
+        read: Nur Lesezugriff
+        read/write: Lese- und Schreibzugriff
+        write: Nur Schreibzugriff
+      title:
+        accounts: Konten
+        admin/accounts: Kontenverwaltung
+        admin/all: Alle administrativen Funktionen
+        admin/reports: Meldungen verwalten
+        all: Voller Zugriff auf dein Mastodon-Konto
+        blocks: Blockierungen
+        bookmarks: Lesezeichen
+        conversations: Private Erwähnungen
+        crypto: Ende-zu-Ende-Verschlüsselung
+        favourites: Favoriten
+        filters: Filter
+        follow: Folge ich, Stummschaltungen und Blockierungen
+        follows: Folge ich
+        lists: Listen
+        media: Medienanhänge
+        mutes: Stummschaltungen
+        notifications: Benachrichtigungen
+        profile: Dein Mastodon-Profil
+        push: Push-Benachrichtigungen
+        reports: Meldungen
+        search: Suche
+        statuses: Beiträge
+    layouts:
+      admin:
+        nav:
+          applications: Anwendungen
+          oauth2_provider: OAuth2-Anbieter
+      application:
+        title: OAuth-Autorisierung erforderlich
+    scopes:
+      admin:read: alle Daten auf dem Server lesen
+      admin:read:accounts: sensible Informationen aller Konten lesen
+      admin:read:canonical_email_blocks: sensible Informationen aller kanonischen E-Mail-Sperren lesen
+      admin:read:domain_allows: sensible Informationen aller zugelassenen Domains lesen
+      admin:read:domain_blocks: sensible Informationen aller Domain-Sperren lesen
+      admin:read:email_domain_blocks: sensible Informationen aller E-Mail-Domain-Sperren lesen
+      admin:read:ip_blocks: sensible Informationen aller IP-Sperren lesen
+      admin:read:reports: sensible Informationen aller Meldungen und gemeldeten Konten lesen
+      admin:write: alle Daten auf dem Server ändern
+      admin:write:accounts: Moderationsaktionen auf Konten ausführen
+      admin:write:canonical_email_blocks: Moderationsaktionen auf kanonischen E-Mail-Sperren ausführen
+      admin:write:domain_allows: Moderationsaktionen auf zugelassende Domains ausführen
+      admin:write:domain_blocks: Moderationsaktionen auf Domain-Sperren ausführen
+      admin:write:email_domain_blocks: Moderationsaktionen auf E-Mail-Domain-Sperren ausführen
+      admin:write:ip_blocks: Moderationsaktionen auf IP-Sperren ausführen
+      admin:write:reports: Moderationsaktionen auf Meldungen ausführen
+      crypto: Ende-zu-Ende-Verschlüsselung verwenden
+      follow: Kontenbeziehungen verändern
+      profile: nur die Profilinformationen deines Kontos lesen
+      push: deine Push-Benachrichtigungen erhalten
+      read: all deine Daten lesen
+      read:accounts: deine Kontoinformationen einsehen
+      read:blocks: deine Blockierungen einsehen
+      read:bookmarks: deine Lesezeichen lesen
+      read:favourites: deine Favoriten einsehen
+      read:filters: deine Filter einsehen
+      read:follows: sehen, wem du folgst
+      read:lists: deine Listen sehen
+      read:mutes: deine Stummschaltungen einsehen
+      read:notifications: deine Benachrichtigungen sehen
+      read:reports: deine Meldungen sehen
+      read:search: in deinem Namen suchen
+      read:statuses: alle Beiträge sehen
+      write: all deine Kontodaten verändern
+      write:accounts: dein Profil bearbeiten
+      write:blocks: Domains und Konten blockieren
+      write:bookmarks: Lesezeichen hinzufügen
+      write:conversations: Unterhaltungen stummschalten und löschen
+      write:favourites: Beiträge favorisieren
+      write:filters: Filter erstellen
+      write:follows: Profilen folgen
+      write:lists: Listen erstellen
+      write:media: Mediendateien hochladen
+      write:mutes: Profile und Unterhaltungen stummschalten
+      write:notifications: deine Benachrichtigungen löschen
+      write:reports: andere Profile melden
+      write:statuses: Beiträge veröffentlichen

--- a/config/locales/doorkeeper.hsb.yml
+++ b/config/locales/doorkeeper.hsb.yml
@@ -1,0 +1,198 @@
+---
+hsb:
+  activerecord:
+    attributes:
+      doorkeeper/application:
+        name: Anwendungsname
+        redirect_uri: Weiterleitungs-URI
+        scopes: Befugnisse
+        website: Website der Anwendung
+    errors:
+      models:
+        doorkeeper/application:
+          attributes:
+            redirect_uri:
+              fragment_present: darf kein Fragment enthalten.
+              invalid_uri: muss ein valider URI sein.
+              relative_uri: muss ein absoluter URI sein.
+              secured_uri: muss ein HTTPS-/SSL-URI sein.
+  doorkeeper:
+    applications:
+      buttons:
+        authorize: Autorisieren
+        cancel: Abbrechen
+        destroy: Löschen
+        edit: Bearbeiten
+        submit: Speichern
+      confirmations:
+        destroy: Bist du dir sicher?
+      edit:
+        title: Anwendung bearbeiten
+      form:
+        error: Ups! Bitte überprüfe das Formular auf mögliche Fehler
+      help:
+        native_redirect_uri: Verwende %{native_redirect_uri} für lokale Tests
+        redirect_uri: Verwende eine Zeile pro URI
+        scopes: Bitte die Befugnisse mit Leerzeichen trennen. Zur Verwendung der Standardwerte freilassen.
+      index:
+        application: Anwendung
+        callback_url: Callback-URL
+        delete: Löschen
+        empty: Du hast keine Anwendungen.
+        name: Name
+        new: Neue Anwendung
+        scopes: Befugnisse
+        show: Anzeigen
+        title: Deine Anwendungen
+      new:
+        title: Neue Anwendung
+      show:
+        actions: Aktionen
+        application_id: Client-Schlüssel
+        callback_urls: Callback-URLs
+        scopes: Befugnisse
+        secret: Client-Secret
+        title: 'Anwendung: %{name}'
+    authorizations:
+      buttons:
+        authorize: Autorisieren
+        deny: Verweigern
+      error:
+        title: Ein Fehler ist aufgetreten
+      new:
+        prompt_html: "%{client_name} möchte auf dein Konto zugreifen. <strong>Du solltest diese Anfrage nur genehmigen, wenn du diese Quelle kennst und ihr vertraust.</strong>"
+        review_permissions: Berechtigungen überprüfen
+        title: Autorisierung erforderlich
+      show:
+        title: Kopiere diesen Autorisierungs-Code und füge ihn in die Anwendung ein.
+    authorized_applications:
+      buttons:
+        revoke: Widerrufen
+      confirmations:
+        revoke: Bist du dir sicher?
+      index:
+        authorized_at: Autorisiert am %{date}
+        description_html: Dies sind Anwendungen, die über die Programmierschnittstelle (API) auf dein Konto zugreifen können. Wenn es Anwendungen gibt, die du hier nicht zuordnen kannst oder wenn sich eine Anwendung verdächtig verhält, kannst du den Zugriff widerrufen.
+        last_used_at: Zuletzt verwendet am %{date}
+        never_used: Nie verwendet
+        scopes: Berechtigungen
+        superapp: Intern
+        title: Deine autorisierten Anwendungen
+    errors:
+      messages:
+        access_denied: Diese Anfrage wurde von den Inhaber*innen oder durch den Autorisierungsserver abgelehnt.
+        credential_flow_not_configured: Das Konto konnte nicht gefunden werden, da Doorkeeper.configure.resource_owner_from_credentials nicht konfiguriert ist.
+        invalid_client: 'Client-Authentisierung ist fehlgeschlagen: Client unbekannt, keine Authentisierung mitgeliefert oder Authentisierungsmethode wird nicht unterstützt.'
+        invalid_code_challenge_method: Die Code-Challenge-Methode muss „S256“ sein, „plain“ wird nicht unterstützt.
+        invalid_grant: Die beigefügte Autorisierung ist ungültig, abgelaufen, wurde widerrufen oder einem anderen Client ausgestellt, oder der Weiterleitungs-URI stimmt nicht mit der Autorisierungs-Anfrage überein.
+        invalid_redirect_uri: Der beigefügte Weiterleitungs-URI ist ungültig.
+        invalid_request:
+          missing_param: 'Erforderlicher Parameter fehlt: %{value}.'
+          request_not_authorized: Anfrage muss autorisiert werden. Benötigter Parameter für die Autorisierung der Anfrage fehlt oder ungültig.
+          unknown: Der Anfrage fehlt ein benötigter Parameter, enthält einen nicht unterstützten Parameterwert oder ist anderweitig fehlerhaft.
+        invalid_resource_owner: Die angegebenen Zugangsdaten für das Konto sind ungültig, oder das Konto kann nicht gefunden werden
+        invalid_scope: Die angeforderte Befugnis ist ungültig, unbekannt oder fehlerhaft.
+        invalid_token:
+          expired: Der Zugriffstoken ist abgelaufen
+          revoked: Der Zugriffstoken wurde widerrufen
+          unknown: Der Zugriffstoken ist ungültig
+        resource_owner_authenticator_not_configured: Das Konto konnte nicht gefunden werden, da Doorkeeper.configure.resource_owner_authenticator nicht konfiguriert ist.
+        server_error: Der Autorisierungs-Server hat ein unerwartetes Problem festgestellt und konnte die Anfrage nicht bearbeiten.
+        temporarily_unavailable: Der Autorisierungs-Server ist aufgrund von zwischenzeitlicher Überlastung oder Wartungsarbeiten derzeit nicht in der Lage, die Anfrage zu bearbeiten.
+        unauthorized_client: Der Client ist nicht dazu autorisiert, diese Anfrage mit dieser Methode auszuführen.
+        unsupported_grant_type: Der Autorisierungs-Typ wird nicht vom Autorisierungs-Server unterstützt.
+        unsupported_response_type: Der Autorisierungs-Server unterstützt diesen Antwort-Typ nicht.
+    flash:
+      applications:
+        create:
+          notice: Anwendung erstellt.
+        destroy:
+          notice: Anwendung gelöscht.
+        update:
+          notice: Anwendung aktualisiert.
+      authorized_applications:
+        destroy:
+          notice: Anwendung widerrufen.
+    grouped_scopes:
+      access:
+        read: Nur Lesezugriff
+        read/write: Lese- und Schreibzugriff
+        write: Nur Schreibzugriff
+      title:
+        accounts: Konten
+        admin/accounts: Kontenverwaltung
+        admin/all: Alle administrativen Funktionen
+        admin/reports: Meldungen verwalten
+        all: Voller Zugriff auf dein Mastodon-Konto
+        blocks: Blockierungen
+        bookmarks: Lesezeichen
+        conversations: Private Erwähnungen
+        crypto: Ende-zu-Ende-Verschlüsselung
+        favourites: Favoriten
+        filters: Filter
+        follow: Folge ich, Stummschaltungen und Blockierungen
+        follows: Folge ich
+        lists: Listen
+        media: Medienanhänge
+        mutes: Stummschaltungen
+        notifications: Benachrichtigungen
+        profile: Dein Mastodon-Profil
+        push: Push-Benachrichtigungen
+        reports: Meldungen
+        search: Suche
+        statuses: Beiträge
+    layouts:
+      admin:
+        nav:
+          applications: Anwendungen
+          oauth2_provider: OAuth2-Anbieter
+      application:
+        title: OAuth-Autorisierung erforderlich
+    scopes:
+      admin:read: alle Daten auf dem Server lesen
+      admin:read:accounts: sensible Informationen aller Konten lesen
+      admin:read:canonical_email_blocks: sensible Informationen aller kanonischen E-Mail-Sperren lesen
+      admin:read:domain_allows: sensible Informationen aller zugelassenen Domains lesen
+      admin:read:domain_blocks: sensible Informationen aller Domain-Sperren lesen
+      admin:read:email_domain_blocks: sensible Informationen aller E-Mail-Domain-Sperren lesen
+      admin:read:ip_blocks: sensible Informationen aller IP-Sperren lesen
+      admin:read:reports: sensible Informationen aller Meldungen und gemeldeten Konten lesen
+      admin:write: alle Daten auf dem Server ändern
+      admin:write:accounts: Moderationsaktionen auf Konten ausführen
+      admin:write:canonical_email_blocks: Moderationsaktionen auf kanonischen E-Mail-Sperren ausführen
+      admin:write:domain_allows: Moderationsaktionen auf zugelassende Domains ausführen
+      admin:write:domain_blocks: Moderationsaktionen auf Domain-Sperren ausführen
+      admin:write:email_domain_blocks: Moderationsaktionen auf E-Mail-Domain-Sperren ausführen
+      admin:write:ip_blocks: Moderationsaktionen auf IP-Sperren ausführen
+      admin:write:reports: Moderationsaktionen auf Meldungen ausführen
+      crypto: Ende-zu-Ende-Verschlüsselung verwenden
+      follow: Kontenbeziehungen verändern
+      profile: nur die Profilinformationen deines Kontos lesen
+      push: deine Push-Benachrichtigungen erhalten
+      read: all deine Daten lesen
+      read:accounts: deine Kontoinformationen einsehen
+      read:blocks: deine Blockierungen einsehen
+      read:bookmarks: deine Lesezeichen lesen
+      read:favourites: deine Favoriten einsehen
+      read:filters: deine Filter einsehen
+      read:follows: sehen, wem du folgst
+      read:lists: deine Listen sehen
+      read:mutes: deine Stummschaltungen einsehen
+      read:notifications: deine Benachrichtigungen sehen
+      read:reports: deine Meldungen sehen
+      read:search: in deinem Namen suchen
+      read:statuses: alle Beiträge sehen
+      write: all deine Kontodaten verändern
+      write:accounts: dein Profil bearbeiten
+      write:blocks: Domains und Konten blockieren
+      write:bookmarks: Lesezeichen hinzufügen
+      write:conversations: Unterhaltungen stummschalten und löschen
+      write:favourites: Beiträge favorisieren
+      write:filters: Filter erstellen
+      write:follows: Profilen folgen
+      write:lists: Listen erstellen
+      write:media: Mediendateien hochladen
+      write:mutes: Profile und Unterhaltungen stummschalten
+      write:notifications: deine Benachrichtigungen löschen
+      write:reports: andere Profile melden
+      write:statuses: Beiträge veröffentlichen

--- a/config/locales/dsb.yml
+++ b/config/locales/dsb.yml
@@ -1,2 +1,2152 @@
 ---
-dsb: {}
+dsb:
+  about:
+    about_mastodon_html: 'Das soziale Netzwerk der Zukunft: Keine Werbung, keine Überwachung durch Unternehmen – dafür dezentral und mit Anstand! Behalte mit Mastodon die Kontrolle über deine Daten!'
+    contact_missing: Nicht festgelegt
+    contact_unavailable: Nicht verfügbar
+    hosted_on: Mastodon, gehostet auf %{domain}
+    title: Über
+  accounts:
+    followers:
+      one: Follower
+      other: Follower
+    following: Folge ich
+    instance_actor_flash: Dieses Konto ist ein virtueller Akteur, der den Server selbst repräsentiert, und kein persönliches Profil. Es wird für Föderationszwecke verwendet und sollte daher nicht gesperrt werden.
+    last_active: zuletzt aktiv
+    link_verified_on: Das Profil mit dieser E-Mail-Adresse wurde bereits am %{date} bestätigt
+    nothing_here: Keine Treffer mit dieser Auswahl
+    pin_errors:
+      following: Du musst dieser Person folgen, um sie empfehlen zu können
+    posts:
+      one: Beitrag
+      other: Beiträge
+    posts_tab_heading: Beiträge
+    self_follow_error: Es ist nicht erlaubt, deinem eigenen Konto zu folgen
+  admin:
+    account_actions:
+      action: Aktion ausführen
+      already_silenced: Dieses Konto wurde bereits eingeschränkt.
+      already_suspended: Dieses Konto wurde bereits gesperrt.
+      title: "@%{acct} moderieren"
+    account_moderation_notes:
+      create: Notiz abspeichern
+      created_msg: Moderationshinweis erfolgreich abgespeichert!
+      destroyed_msg: Moderationsnotiz erfolgreich entfernt!
+    accounts:
+      add_email_domain_block: E-Mail-Domain sperren
+      approve: Genehmigen
+      approved_msg: Antrag zur Registrierung von %{username} erfolgreich genehmigt
+      are_you_sure: Bist du dir sicher?
+      avatar: Profilbild
+      by_domain: Domain
+      change_email:
+        changed_msg: E-Mail-Adresse erfolgreich geändert!
+        current_email: Aktuelle E-Mail-Adresse
+        label: E-Mail-Adresse ändern
+        new_email: Neue E-Mail-Adresse
+        submit: E-Mail-Adresse ändern
+        title: E-Mail-Adresse für %{username} ändern
+      change_role:
+        changed_msg: Rolle erfolgreich geändert!
+        edit_roles: Rollen verwalten
+        label: Rolle ändern
+        no_role: Keine Rolle
+        title: Rolle für %{username} ändern
+      confirm: Bestätigen
+      confirmed: Bestätigt
+      confirming: Bestätigung
+      custom: Angepasst
+      delete: Daten löschen
+      deleted: Gelöscht
+      demote: Zurückstufen
+      destroyed_msg: Daten von %{username} wurden zum Löschen in die Warteschlange eingereiht
+      disable: Einfrieren
+      disable_sign_in_token_auth: E-Mail-Token-Authentisierung deaktivieren
+      disable_two_factor_authentication: Zwei-Faktor-Authentisierung deaktivieren
+      disabled: Eingefroren
+      display_name: Anzeigename
+      domain: Domain
+      edit: Bearbeiten
+      email: E-Mail-Adresse
+      email_status: Status der E-Mail-Adresse
+      enable: Freischalten
+      enable_sign_in_token_auth: E-Mail-Token-Authentisierung aktivieren
+      enabled: Freigegeben
+      enabled_msg: Konto von %{username} erfolgreich freigegeben
+      followers: Follower
+      follows: Folge ich
+      header: Titelbild
+      inbox_url: Posteingangsadresse
+      invite_request_text: Begründung für das Beitreten
+      invited_by: Eingeladen von
+      ip: IP-Adresse
+      joined: Mitglied seit
+      location:
+        all: Alle
+        local: Lokal
+        remote: Extern
+        title: Herkunft
+      login_status: Status
+      media_attachments: Medienanhänge
+      memorialize: In Gedenkseite umwandeln
+      memorialized: Gedenkseite
+      memorialized_msg: "%{username} wurde erfolgreich in ein Gedenkseiten-Konto umgewandelt"
+      moderation:
+        active: Aktiv
+        all: Alle
+        disabled: Deaktiviert
+        pending: In Warteschlange
+        silenced: Stummgeschaltet
+        suspended: Gesperrt
+        title: Moderation
+      moderation_notes: Moderationsnotizen
+      most_recent_activity: Letzte Aktivität
+      most_recent_ip: Letzte IP-Adresse
+      no_account_selected: Keine Konten wurden geändert, da keine ausgewählt wurden
+      no_limits_imposed: Keine Beschränkungen
+      no_role_assigned: Keine Rolle zugewiesen
+      not_subscribed: Nicht abonniert
+      pending: Überprüfung ausstehend
+      perform_full_suspension: Sperren
+      previous_strikes: Vorherige Maßnahmen
+      previous_strikes_description_html:
+        one: Gegen dieses Konto wurde <strong>eine</strong> Maßnahme verhängt.
+        other: Gegen dieses Konto wurden <strong>%{count}</strong> Maßnahmen verhängt.
+      promote: Berechtigungen erweitern
+      protocol: Protokoll
+      public: Öffentlich
+      push_subscription_expires: PuSH-Abonnement läuft aus
+      redownload: Profil neu laden
+      redownloaded_msg: Das Profil %{username} wurde vom externen Server erfolgreich aktualisiert
+      reject: Ablehnen
+      rejected_msg: Antrag zur Registrierung von %{username} erfolgreich abgelehnt
+      remote_suspension_irreversible: Die Daten dieses Kontos wurden unwiderruflich gelöscht.
+      remote_suspension_reversible_hint_html: Das Konto wurde auf dem externen Server gesperrt – und sämtliche Daten werden am %{date} entfernt. Bis dahin kann dieser Server das Konto ohne negative Auswirkungen wiederherstellen. Wenn du schon jetzt alle Daten des Kontos unwiderruflich löschen möchtest, kannst du dies nachfolgend tun.
+      remove_avatar: Profilbild entfernen
+      remove_header: Titelbild entfernen
+      removed_avatar_msg: Profilbild von %{username} erfolgreich entfernt
+      removed_header_msg: Titelbild von %{username} wurde erfolgreich entfernt
+      resend_confirmation:
+        already_confirmed: Dieses Profil wurde bereits bestätigt
+        send: Bestätigungslink erneut zusenden
+        success: Bestätigungslink erfolgreich gesendet!
+      reset: Zurücksetzen
+      reset_password: Passwort zurücksetzen
+      resubscribe: Erneut abonnieren
+      role: Rolle
+      search: Suchen
+      search_same_email_domain: Andere Konten mit der gleichen E-Mail-Domain
+      search_same_ip: Andere Konten mit derselben IP-Adresse
+      security: Sicherheit
+      security_measures:
+        only_password: Nur Passwort
+        password_and_2fa: Passwort und 2FA
+      sensitive: Inhaltswarnung
+      sensitized: Mit Inhaltswarnung versehen
+      shared_inbox_url: Geteilte Posteingangsadresse
+      show:
+        created_reports: Erstellte Meldungen
+        targeted_reports: Von Anderen gemeldet
+      silence: Stummschalten
+      silenced: Stummgeschaltet
+      statuses: Beiträge
+      strikes: Vorherige Maßnahmen
+      subscribe: Abonnieren
+      suspend: Sperren
+      suspended: Gesperrt
+      suspension_irreversible: Die Daten dieses Kontos wurden unwiderruflich gelöscht. Du kannst das Konto entsperren, um es wieder zu verwenden, aber es wird keine Daten wiederherstellen, die es davor hatte.
+      suspension_reversible_hint_html: Das Konto wurde gesperrt und die Daten werden am %{date} vollständig gelöscht. Bis dahin kann das Konto ohne irgendwelche negativen Auswirkungen wiederhergestellt werden. Wenn du alle Daten des Kontos sofort entfernen möchtest, kannst du das nachfolgend tun.
+      title: Konten
+      unblock_email: E-Mail-Adresse entsperren
+      unblocked_email_msg: E-Mail-Adresse von %{username} erfolgreich entsperrt
+      unconfirmed_email: Unbestätigte E-Mail-Adresse
+      undo_sensitized: Inhaltswarnung aufheben
+      undo_silenced: Stummschaltung aufheben
+      undo_suspension: Sperre aufheben
+      unsilenced_msg: Konto von %{username} erfolgreich freigegeben
+      unsubscribe: Abbestellen
+      unsuspended_msg: Kontosperre von %{username} erfolgreich aufgehoben
+      username: Profilname
+      view_domain: Übersicht für Domain anzeigen
+      warn: Verwarnen
+      web: Web
+      whitelisted: Für Föderation zugelassen
+    action_logs:
+      action_types:
+        approve_appeal: Einspruch zulassen
+        approve_user: Benutzer*in genehmigen
+        assigned_to_self_report: Meldung zuweisen
+        change_email_user: E-Mail des Profils ändern
+        change_role_user: Rolle des Profils ändern
+        confirm_user: Benutzer*in bestätigen
+        create_account_warning: Warnung erstellen
+        create_announcement: Ankündigung erstellen
+        create_canonical_email_block: E-Mail-Sperre erstellen
+        create_custom_emoji: Eigene Emojis erstellen
+        create_domain_allow: Domain erlauben
+        create_domain_block: Domain sperren
+        create_email_domain_block: E-Mail-Domain-Sperre erstellen
+        create_ip_block: IP-Regel erstellen
+        create_relay: Relais erstellen
+        create_unavailable_domain: Nicht verfügbare Domain erstellen
+        create_user_role: Rolle erstellen
+        create_username_block: Regel für Profilnamen erstellen
+        demote_user: Benutzer*in herabstufen
+        destroy_announcement: Ankündigung löschen
+        destroy_canonical_email_block: E-Mail-Sperre entfernen
+        destroy_custom_emoji: Eigenes Emojis löschen
+        destroy_domain_allow: Erlaube das Löschen von Domains
+        destroy_domain_block: Domain-Sperre entfernen
+        destroy_email_domain_block: E-Mail-Domain-Sperre entfernen
+        destroy_instance: Domain-Daten entfernen
+        destroy_ip_block: IP-Regel löschen
+        destroy_relay: Relais löschen
+        destroy_status: Beitrag entfernen
+        destroy_unavailable_domain: Nicht-verfügbare Domain entfernen
+        destroy_user_role: Rolle entfernen
+        destroy_username_block: Regel für Profilnamen löschen
+        disable_2fa_user: 2FA deaktivieren
+        disable_custom_emoji: Eigenes Emoji deaktivieren
+        disable_relay: Relais deaktivieren
+        disable_sign_in_token_auth_user: E-Mail-Token-Authentisierung für dieses Konto deaktivieren
+        disable_user: Benutzer*in deaktivieren
+        enable_custom_emoji: Eigenes Emoji aktivieren
+        enable_relay: Relais aktivieren
+        enable_sign_in_token_auth_user: E-Mail-Token-Authentisierung für dieses Konto aktivieren
+        enable_user: Benutzer*in aktivieren
+        memorialize_account: Gedenkkonto
+        promote_user: Benutzer*in hochstufen
+        publish_terms_of_service: Nutzungsbedingungen veröffentlichen
+        reject_appeal: Einspruch ablehnen
+        reject_user: Benutzer*in ablehnen
+        remove_avatar_user: Profilbild entfernen
+        reopen_report: Meldung wieder eröffnen
+        resend_user: Bestätigungs-E-Mail erneut senden
+        reset_password_user: Passwort zurücksetzen
+        resolve_report: Meldung klären
+        sensitive_account: Konto mit erzwungener Inhaltswarnung
+        silence_account: Konto stummschalten
+        suspend_account: Konto sperren
+        unassigned_report: Meldung widerrufen
+        unblock_email_account: E-Mail-Adresse entsperren
+        unsensitive_account: Konto mit erzwungener Inhaltswarnung rückgängig machen
+        unsilence_account: Konto nicht mehr stummschalten
+        unsuspend_account: Konto entsperren
+        update_announcement: Ankündigung aktualisieren
+        update_custom_emoji: Eigenes Emoji aktualisieren
+        update_domain_block: Domain-Sperre aktualisieren
+        update_ip_block: IP-Regel aktualisieren
+        update_report: Meldung aktualisieren
+        update_status: Beitrag aktualisieren
+        update_user_role: Rolle bearbeiten
+        update_username_block: Regel für Profilnamen aktualisieren
+      actions:
+        approve_appeal_html: "%{name} hat den Einspruch gegen eine Moderationsentscheidung von %{target} genehmigt"
+        approve_user_html: "%{name} genehmigte die Registrierung von %{target}"
+        assigned_to_self_report_html: "%{name} wies sich die Meldung %{target} selbst zu"
+        change_email_user_html: "%{name} änderte die E-Mail-Adresse von %{target}"
+        change_role_user_html: "%{name} hat die Rolle von %{target} geändert"
+        confirm_user_html: "%{name} bestätigte die E-Mail-Adresse von %{target}"
+        create_account_warning_html: "%{name} sendete eine Warnung an %{target}"
+        create_announcement_html: "%{name} erstellte die neue Ankündigung: %{target}"
+        create_canonical_email_block_html: "%{name} sperrte die E-Mail mit dem Hash %{target}"
+        create_custom_emoji_html: "%{name} lud das neue Emoji %{target} hoch"
+        create_domain_allow_html: "%{name} erlaubte die Föderation mit der Domain %{target}"
+        create_domain_block_html: "%{name} sperrte die Domain %{target}"
+        create_email_domain_block_html: "%{name} sperrte die E-Mail-Domain %{target}"
+        create_ip_block_html: "%{name} erstellte eine IP-Regel für %{target}"
+        create_relay_html: "%{name} erstellte ein Relay %{target}"
+        create_unavailable_domain_html: "%{name} beendete die Zustellung an die Domain %{target}"
+        create_user_role_html: "%{name} erstellte die Rolle %{target}"
+        create_username_block_html: "%{name} erstellte eine Regel für Profilnamen mit %{target}"
+        demote_user_html: "%{name} stufte %{target} herunter"
+        destroy_announcement_html: "%{name} löschte die Ankündigung %{target}"
+        destroy_canonical_email_block_html: "%{name} entsperrte die E-Mail mit dem Hash %{target}"
+        destroy_custom_emoji_html: "%{name} löschte das Emoji %{target}"
+        destroy_domain_allow_html: "%{name} verwehrte die Föderation mit der Domain %{target}"
+        destroy_domain_block_html: "%{name} entsperrte die Domain %{target}"
+        destroy_email_domain_block_html: "%{name} entsperrte die E-Mail-Domain %{target}"
+        destroy_instance_html: "%{name} entfernte die Daten der Domain %{target} von diesem Server"
+        destroy_ip_block_html: "%{name} entfernte eine IP-Regel für %{target}"
+        destroy_relay_html: "%{name} löschte das Relais %{target}"
+        destroy_status_html: "%{name} entfernte einen Beitrag von %{target}"
+        destroy_unavailable_domain_html: "%{name} nahm die Zustellung an die Domain %{target} wieder auf"
+        destroy_user_role_html: "%{name} löschte die Rolle %{target}"
+        destroy_username_block_html: "%{name} entfernte eine Regel für Profilnamen mit %{target}"
+        disable_2fa_user_html: "%{name} deaktivierte die Zwei-Faktor-Authentisierung für %{target}"
+        disable_custom_emoji_html: "%{name} deaktivierte das Emoji %{target}"
+        disable_relay_html: "%{name} deaktivierte das Relais %{target}"
+        disable_sign_in_token_auth_user_html: "%{name} deaktivierte die E-Mail-Token-Authentisierung für %{target}"
+        disable_user_html: "%{name} deaktivierte den Zugang für %{target}"
+        enable_custom_emoji_html: "%{name} aktivierte das Emoji %{target}"
+        enable_relay_html: "%{name} aktivierte das Relais %{target}"
+        enable_sign_in_token_auth_user_html: "%{name} aktivierte die E-Mail-Token-Authentisierung für %{target}"
+        enable_user_html: "%{name} aktivierte den Zugang für %{target}"
+        memorialize_account_html: "%{name} wandelte das Konto von %{target} in eine Gedenkseite um"
+        promote_user_html: "%{name} beförderte %{target}"
+        publish_terms_of_service_html: "%{name} aktualisierte die Nutzungsbedingungen"
+        reject_appeal_html: "%{name} hat den Einspruch gegen eine Moderationsentscheidung von %{target} abgelehnt"
+        reject_user_html: "%{name} hat die Registrierung von %{target} abgelehnt"
+        remove_avatar_user_html: "%{name} entfernte das Profilbild von %{target}"
+        reopen_report_html: "%{name} öffnete die Meldung %{target} wieder"
+        resend_user_html: "%{name} versendete erneut die E-Mail-Bestätigung für %{target}"
+        reset_password_user_html: "%{name} setzte das Passwort von %{target} zurück"
+        resolve_report_html: "%{name} klärte die Meldung %{target}"
+        sensitive_account_html: "%{name} versah die Medien von %{target} mit einer Inhaltswarnung"
+        silence_account_html: "%{name} schaltete das Konto von %{target} stumm"
+        suspend_account_html: "%{name} sperrte das Konto von %{target}"
+        unassigned_report_html: "%{name} entfernte die Zuweisung der Meldung %{target}"
+        unblock_email_account_html: "%{name} hat die E-Mail-Adresse von %{target} entsperrt"
+        unsensitive_account_html: "%{name} hat die Inhaltswarnung für Medien von %{target} aufgehoben"
+        unsilence_account_html: "%{name} hob die Stummschaltung von %{target} auf"
+        unsuspend_account_html: "%{name} entsperrte das Konto von %{target}"
+        update_announcement_html: "%{name} überarbeitete die Ankündigung %{target}"
+        update_custom_emoji_html: "%{name} bearbeitete das Emoji %{target}"
+        update_domain_block_html: "%{name} aktualisierte die Domain-Sperre für %{target}"
+        update_ip_block_html: "%{name} änderte die Regel für die IP-Adresse %{target}"
+        update_report_html: "%{name} überarbeitete die Meldung %{target}"
+        update_status_html: "%{name} überarbeitete einen Beitrag von %{target}"
+        update_user_role_html: "%{name} änderte die Rolle von %{target}"
+        update_username_block_html: "%{name} aktualisierte eine Regel für Profilnamen mit %{target}"
+      deleted_account: gelöschtes Konto
+      empty: Protokolle nicht gefunden.
+      filter_by_action: Nach Aktion filtern
+      filter_by_user: Nach Benutzer*in filtern
+      title: Audit-Log
+      unavailable_instance: "(Server nicht verfügbar)"
+    announcements:
+      back: Zurück zu den Ankündigungen
+      destroyed_msg: Ankündigung erfolgreich gelöscht!
+      edit:
+        title: Ankündigung bearbeiten
+      empty: Keine Ankündigungen vorhanden.
+      live: Aktuell gültig
+      new:
+        create: Ankündigung erstellen
+        title: Neue Ankündigung
+      preview:
+        disclaimer: Da sich Profile nicht davon abmelden können, sollten Benachrichtigungen per E-Mail auf wichtige Ankündigungen wie z. B. zu Datenpannen oder Serverabschaltung beschränkt sein.
+        explanation_html: 'Die E-Mail wird an <strong>%{display_count} Nutzer*innen</strong> gesendet. Folgendes wird in der E-Mail enthalten sein:'
+        title: Vorschau der Ankündigung
+      publish: Veröffentlichen
+      published_msg: Ankündigung erfolgreich veröffentlicht!
+      scheduled_for: Geplant für %{time}
+      scheduled_msg: Ankündigung ist zur Veröffentlichung vorgemerkt!
+      title: Ankündigungen
+      unpublish: Veröffentlichung rückgängig machen
+      unpublished_msg: Ankündigung ist jetzt nicht mehr sichtbar!
+      updated_msg: Ankündigung erfolgreich aktualisiert!
+    critical_update_pending: Kritisches Update ausstehend
+    custom_emojis:
+      assign_category: Kategorie zuweisen
+      by_domain: Domain
+      copied_msg: Lokale Kopie des Emojis erfolgreich erstellt
+      copy: Kopieren
+      copy_failed_msg: Es konnte keine lokale Kopie dieses Emojis auf diesem Server erstellt werden
+      create_new_category: Neue Kategorie erstellen
+      created_msg: Emoji erfolgreich erstellt!
+      delete: Löschen
+      destroyed_msg: Emoji erfolgreich gelöscht!
+      disable: Deaktivieren
+      disabled: Deaktiviert
+      disabled_msg: Dieses Emoji wurde erfolgreich deaktiviert
+      emoji: Emoji
+      enable: Aktivieren
+      enabled: Aktiviert
+      enabled_msg: Dieses Emoji wurde erfolgreich aktiviert
+      image_hint: PNG oder GIF bis %{size}
+      list: Anzeigen
+      listed: Sichtbar
+      new:
+        title: Eigenes Emoji hinzufügen
+      no_emoji_selected: Keine Emojis wurden bearbeitet, da keine ausgewählt wurden
+      not_permitted: Du bist für die Durchführung dieses Vorgangs nicht berechtigt
+      overwrite: Überschreiben
+      shortcode: Shortcode
+      shortcode_hint: Mindestens 2 Zeichen, nur Buchstaben, Ziffern und Unterstriche
+      title: Eigene Emojis
+      uncategorized: Unkategorisiert
+      unlist: Nicht anzeigen
+      unlisted: Öffentlich (still)
+      update_failed_msg: Konnte dieses Emoji nicht bearbeiten
+      updated_msg: Emoji erfolgreich bearbeitet!
+      upload: Hochladen
+    dashboard:
+      active_users: aktive Profile
+      interactions: Interaktionen
+      media_storage: Medien
+      new_users: neue Profile
+      opened_reports: eingereichte Meldungen
+      pending_appeals_html:
+        one: "<strong>%{count}</strong> ausstehender Einspruch"
+        other: "<strong>%{count}</strong> ausstehende Einsprüche"
+      pending_reports_html:
+        one: "<strong>%{count}</strong> offene Meldung"
+        other: "<strong>%{count}</strong> offene Meldungen"
+      pending_tags_html:
+        one: "<strong>%{count}</strong> ungeprüfter Hashtag"
+        other: "<strong>%{count}</strong> ungeprüfte Hashtags"
+      pending_users_html:
+        one: "<strong>%{count}</strong> unerledigte*r Benutzer*in"
+        other: "<strong>%{count}</strong> unerledigte Benutzer*innen"
+      resolved_reports: geklärte Meldungen
+      software: Programme
+      sources: Registrierungsort
+      space: Speicherplatz
+      title: Dashboard
+      top_languages: Häufigste Sprachen
+      top_servers: Aktivste Server
+      website: Website
+    disputes:
+      appeals:
+        empty: Keine Einsprüche gefunden.
+        title: Einsprüche
+    domain_allows:
+      add_new: Föderation mit Domain erlauben
+      created_msg: Domain wurde erfolgreich für die Föderation zugelassen
+      destroyed_msg: Domain wurde von der Föderation ausgeschlossen
+      export: Exportieren
+      import: Importieren
+      undo: Von der Föderation ausschließen
+    domain_blocks:
+      add_new: Neue Domain einschränken
+      confirm_suspension:
+        cancel: Abbrechen
+        confirm: Sperren
+        permanent_action: Das Aufheben der Sperre wird keine Daten oder Beziehungen wiederherstellen.
+        preamble_html: Du bist dabei, <strong>%{domain}</strong> und alle Subdomains zu sperren.
+        remove_all_data: Alle Inhalte, Medien und Profildaten werden für die Konten dieser Domain von deinem Server entfernt.
+        stop_communication: Dein Server wird nicht länger mit diesen Servern kommunizieren.
+        title: Sperre für Domain %{domain} bestätigen
+        undo_relationships: Jede Follower-Beziehung, die zwischen deinem und deren Server besteht, wird aufgelöst.
+      created_msg: Die Domain ist jetzt gesperrt bzw. eingeschränkt
+      destroyed_msg: Die Einschränkungen zu dieser Domain wurde entfernt
+      domain: Domain
+      edit: Einschränkungen bearbeiten
+      existing_domain_block: Du hast %{name} bereits stärker eingeschränkt.
+      existing_domain_block_html: Du hast bereits strengere Beschränkungen für die Domain %{name} verhängt. Du musst diese erst <a href="%{unblock_url}">aufheben</a>.
+      export: Exportieren
+      import: Importieren
+      new:
+        create: Server einschränken
+        hint: Die Einschränkung einer Domain wird nicht verhindern, dass Konteneinträge in der Datenbank erstellt werden. Es werden aber alle Moderationsmethoden rückwirkend und automatisch auf diese Konten angewendet.
+        severity:
+          desc_html: "<strong>Stummschalten</strong> wird Beiträge von Konten unter dieser Domain für alle unsichtbar machen, die den Konten nicht folgen. <strong>Sperren</strong> wird alle Inhalte, Medien und Profildaten für die Konten dieser Domain von deinem Server entfernen. Verwende <strong>Kein</strong>, wenn du nur Mediendateien ablehnen möchtest."
+          noop: Kein
+          silence: Stummschaltung
+          suspend: Sperren
+        title: Neue Domain einschränken
+      no_domain_block_selected: Keine Domains gesperrt, weil keine ausgewählt wurde(n)
+      not_permitted: Du bist nicht berechtigt, diese Aktion durchzuführen
+      obfuscate: Domain-Name verschleiern
+      obfuscate_hint: Den Domain-Namen öffentlich nur teilweise bekannt geben, sofern die Liste der Domain-Beschränkungen aktiviert ist
+      private_comment: Nicht-öffentliche Notiz
+      private_comment_hint: Kommentar zu dieser Domain-Beschränkung für die interne Nutzung durch die Moderator*innen.
+      public_comment: Öffentliche Begründung
+      public_comment_hint: Öffentlicher Hinweis zu dieser Domain-Beschränkung, sofern das Veröffentlichen von Sperrlisten grundsätzlich aktiviert ist.
+      reject_media: Mediendateien ablehnen
+      reject_media_hint: Entfernt lokal gespeicherte Mediendateien und verhindert deren künftiges Herunterladen. Für Sperren irrelevant
+      reject_reports: Meldungen ablehnen
+      reject_reports_hint: Alle Meldungen von dieser Domain ignorieren. Irrelevant für Sperrungen.
+      undo: Einschränkungen aufheben
+      view: Domain-Sperre ansehen
+    email_domain_blocks:
+      add_new: Neue hinzufügen
+      allow_registrations_with_approval: Registrierungen mit Genehmigung zulassen
+      attempts_over_week:
+        one: "%{count} Registrierungsversuch in der vergangenen Woche"
+        other: "%{count} Registrierungsversuche in der vergangenen Woche"
+      created_msg: E-Mail-Domain erfolgreich gesperrt
+      delete: Entfernen
+      dns:
+        types:
+          mx: MX-RR-Eintrag
+      domain: Domain
+      new:
+        create: E-Mail-Domain hinzufügen
+        resolve: Domain auflösen
+        title: Neue E-Mail-Domain sperren
+      no_email_domain_block_selected: Es wurden keine E-Mail-Domain-Sperren geändert, da keine ausgewählt wurden
+      not_permitted: Nicht gestattet
+      resolved_dns_records_hint_html: Die Domain wird zu den folgenden MX-Domains aufgelöst, die für die Annahme von E-Mails zuständig sind. Das Sperren einer MX-Domain sperrt Anmeldungen aller E-Mail-Adressen, die dieselbe MX-Domain verwenden, auch wenn die sichtbare Domain anders lautet. <strong>Achte daher darauf, keine großen E-Mail-Anbieter versehentlich zu sperren.</strong>
+      resolved_through_html: Durch %{domain} aufgelöst
+      title: Gesperrte E-Mail-Domains
+    export_domain_allows:
+      new:
+        title: Erlaubte Domains importieren
+      no_file: Keine Datei ausgewählt
+    export_domain_blocks:
+      import:
+        description_html: Du bist dabei, eine Liste von Domains zu importieren, die auf diesem Server gesperrt oder anderweitig eingeschränkt werden. Bitte überprüfe diese Liste sehr sorgfältig, insbesondere dann, wenn du sie nicht selbst erstellt hast.
+        existing_relationships_warning: Vorhandene Follower-Beziehungen
+        private_comment_description_html: 'Damit du später nachvollziehen kannst, woher die importierten Sperren stammen, werden sie mit diesem privaten Kommentar erstellt: <q>%{comment}</q>'
+        private_comment_template: Importiert von %{source} am %{date}
+        title: Domains importieren
+      invalid_domain_block: 'Ein oder mehrere Domainsperren wurden wegen folgenden Fehler(n) übersprungen: %{error}'
+      new:
+        title: Domains importieren
+      no_file: Keine Datei ausgewählt
+    fasp:
+      debug:
+        callbacks:
+          created_at: Erstellt am
+          delete: Entfernen
+          ip: IP-Adresse
+          request_body: Body anfragen
+          title: Callback testen
+      providers:
+        active: Aktiv
+        base_url: Basis-URL
+        callback: Callback
+        delete: Entfernen
+        edit: Anbieter bearbeiten
+        finish_registration: Registrierung abschließen
+        name: Name
+        providers: Anbieter
+        public_key_fingerprint: Fingerabdruck des öffentlichen Schlüssels
+        registration_requested: Registrierung angefordert
+        registrations:
+          confirm: Bestätigen
+          description: Sie haben eine Registrierung von einer FASP erhalten. Lehnen Sie ab, wenn Sie dies nicht initiiert haben. Wenn Sie dies initiiert haben, vergleichen Sie Namen und Fingerabdruck vor der Bestätigung der Registrierung.
+          reject: Ablehnen
+          title: FASP-Registrierung bestätigen
+        save: Speichern
+        select_capabilities: Leistungsfähigkeit auswählen
+        sign_in: Anmelden
+        status: Status
+        title: Fediverse Auxiliary Service Providers
+      title: FASP
+    follow_recommendations:
+      description_html: "<strong>Follower-Empfehlungen helfen neuen Nutzer*innen, interessante Inhalte schnell zu finden</strong>. Wenn ein*e Nutzer*in noch nicht genug mit anderen interagiert hat, um personalisierte Follower-Empfehlungen zu erhalten, werden stattdessen diese Profile vorgeschlagen. Sie werden täglich, basierend auf einer Mischung aus am meisten interagierenden Konten und jenen mit den meisten Followern für eine bestimmte Sprache neu berechnet."
+      language: Für Sprache
+      status: Status
+      suppress: Folgeempfehlung unterbinden
+      suppressed: Unterdrückt
+      title: Folgeempfehlungen
+      unsuppress: Folgeempfehlung nicht mehr unterbinden
+    instances:
+      audit_log:
+        title: Neueste Audit-Logs
+        view_all: Alle Audit-Logs anzeigen
+      availability:
+        description_html:
+          one: Wenn die Zustellung an die Domain <strong>%{count} Tag</strong> lang erfolglos bleibt, werden keine weiteren Zustellversuche unternommen, bis eine Zustellung <em>von</em> der Domain empfangen wird.
+          other: Wenn die Zustellung an die Domain an <strong>%{count} unterschiedlichen Tagen</strong> erfolglos bleibt, werden keine weiteren Zustellversuche unternommen, bis eine Zustellung <em>von</em> der Domain empfangen wird.
+        failure_threshold_reached: Grenzwert von Fehlschlägen am %{date} überschritten.
+        failures_recorded:
+          one: Fehlgeschlagener Versuch an %{count} Tag.
+          other: Fehlgeschlagene Versuche an %{count} unterschiedlichen Tagen.
+        no_failures_recorded: Keine Fehler bei der Aufzeichnung.
+        title: Verfügbarkeit
+        warning: Der letzte Versuch, sich mit diesem Server zu verbinden, war nicht erfolgreich
+      back_to_all: Alle
+      back_to_limited: Stummgeschaltet
+      back_to_warning: Warnung
+      by_domain: Domain
+      confirm_purge: Möchtest du die Daten von dieser Domain wirklich für immer löschen?
+      content_policies:
+        comment: Nicht-öffentliche Notiz
+        description_html: Du kannst Inhaltsrichtlinien definieren, die auf alle Konten dieser Domain und einer ihrer Subdomains angewendet werden.
+        limited_federation_mode_description_html: Du kannst auswählen, ob du eine Föderation mit dieser Domain erlaubst.
+        policies:
+          reject_media: Medien ablehnen
+          reject_reports: Meldungen ablehnen
+          silence: Stummschaltung
+          suspend: Gesperrt
+        policy: Einschränkung
+        reason: Öffentliche Begründung
+        title: Inhaltsrichtlinien
+      dashboard:
+        instance_accounts_dimension: Meistgefolgte Konten
+        instance_accounts_measure: deren Konten hier im Cache
+        instance_followers_measure: eigene Follower dort
+        instance_follows_measure: deren Follower hier
+        instance_languages_dimension: Häufigste Sprachen
+        instance_media_attachments_measure: deren Medien hier im Cache
+        instance_reports_measure: Meldungen zu deren Konten
+        instance_statuses_measure: deren Beiträge hier im Cache
+      delivery:
+        all: Alle
+        clear: Zustellfehler löschen
+        failing: Fehlerhaft
+        restart: Zustellung neu starten
+        stop: Zustellung beenden
+        unavailable: Nicht verfügbar
+      delivery_available: Zustellung funktioniert
+      delivery_error_days: Tage der fehlerhaften Zustellung
+      delivery_error_hint: Wenn eine Zustellung %{count} Tage lang nicht möglich ist, wird sie automatisch als unzustellbar markiert.
+      destroyed_msg: Daten von %{domain} sind nun in der Warteschlange für die bevorstehende Löschung.
+      empty: Keine Domains gefunden.
+      known_accounts:
+        one: "%{count} bekanntes Konto"
+        other: "%{count} bekannte Konten"
+      moderation:
+        all: Alle
+        limited: Eingeschränkt
+        title: Server
+      moderation_notes:
+        create: Moderationsnotiz hinzufügen
+        created_msg: Moderationsnotiz für diesen Server erfolgreich erstellt!
+        description_html: Hinterlasse Notizen für dich und deine Moderator*innen
+        destroyed_msg: Moderationsnotiz für diesen Server erfolgreich entfernt!
+        placeholder: Informationen über diesen Server, ergriffene Maßnahmen oder andere Sachverhalte, die in Zukunft nützlich sein könnten.
+        title: Moderationsnotizen
+      private_comment: Privater Kommentar
+      public_comment: Öffentlicher Kommentar
+      purge: Säubern
+      purge_description_html: Wenn du glaubst, dass diese Domain endgültig offline ist, dann kannst du alle Kontodatensätze und zugehörigen Daten von diesem Server löschen. Das kann eine Weile dauern.
+      title: Föderation
+      total_blocked_by_us: Von uns gesperrt
+      total_followed_by_them: Gefolgt von denen
+      total_followed_by_us: Gefolgt von uns
+      total_reported: Beschwerden über sie
+      total_storage: Medienanhänge
+      totals_time_period_hint_html: Die unten angezeigten Summen enthalten Daten für alle Zeiten.
+      unknown_instance: Auf diesem Server gibt es derzeit keinen Eintrag dieser Domain.
+    invites:
+      deactivate_all: Alle deaktivieren
+      filter:
+        all: Alle
+        available: Noch gültig
+        expired: Abgelaufen
+        title: Filter
+      title: Einladungen
+    ip_blocks:
+      add_new: Regel erstellen
+      created_msg: Neue IP-Regel erfolgreich hinzugefügt
+      delete: Entfernen
+      expires_in:
+        '1209600': 2 Wochen
+        '15778476': 6 Monate
+        '2629746': 1 Monat
+        '31556952': 1 Jahr
+        '86400': 1 Tag
+        '94670856': 3 Jahre
+      new:
+        title: Neue IP-Regel erstellen
+      no_ip_block_selected: Keine IP-Regeln wurden geändert, weil keine ausgewählt wurde(n)
+      title: IP-Regeln
+    relationships:
+      title: Beziehungen von %{acct}
+    relays:
+      add_new: Neues Relais hinzufügen
+      delete: Entfernen
+      description_html: Ein <strong>Föderierungsrelay</strong> ist ein vermittelnder Server, der eine große Anzahl öffentlicher Beiträge zwischen Servern, die das Relais abonnieren und zu ihm veröffentlichen, austauscht.<strong> Es kann kleinen und mittleren Servern dabei helfen, Inhalte des Fediverse zu entdecken</strong>, was andernfalls das manuelle Folgen anderer Leute auf externen Servern durch lokale Nutzer*innen erfordern würde.
+      disable: Ausschalten
+      disabled: Ausgeschaltet
+      enable: Einschalten
+      enable_hint: Sobald aktiviert, wird dein Server alle öffentlichen Beiträge dieses Relais abonnieren und alle öffentlichen Beiträge dieses Servers an dieses senden.
+      enabled: Eingeschaltet
+      inbox_url: Relay-URL
+      pending: Warte auf Zustimmung des Relays
+      save_and_enable: Speichern und aktivieren
+      setup: Neues Relais verbinden
+      signatures_not_enabled: Die Relais funktionieren nicht korrekt, wenn der abgesicherte Modus aktiviert oder die Föderation eingeschränkt ist
+      status: Status
+      title: Relais
+    report_notes:
+      created_msg: Notiz zur Meldung erfolgreich erstellt!
+      destroyed_msg: Notiz zur Meldung erfolgreich entfernt!
+    reports:
+      account:
+        notes:
+          one: "%{count} Notiz"
+          other: "%{count} Notizen"
+      action_log: Audit-Log
+      action_taken_by: Maßnahme ergriffen von
+      actions:
+        delete_description_html: Der gemeldete Beitrag wird gelöscht und die ergriffene Maßnahme wird aufgezeichnet, um dir bei zukünftigen Verstößen des gleichen Kontos zu helfen.
+        mark_as_sensitive_description_html: Die Medien in den gemeldeten Beiträgen werden mit einer Inhaltswarnung versehen und der Vorfall wird vermerkt, um bei zukünftigen Verstößen desselben Kontos besser reagieren zu können.
+        other_description_html: Weitere Optionen zur Steuerung des Kontoverhaltens und zur Anpassung der Kommunikation mit dem gemeldeten Konto.
+        resolve_description_html: Es wird keine Maßnahme gegen das gemeldete Konto ergriffen und der Vorgang wird nicht aufgezeichnet – die Meldung wird hiermit geschlossen.
+        silence_description_html: Das Konto wird nur für diejenigen sichtbar sein, die dem Konto bereits folgen oder es manuell suchen, was die Reichweite stark einschränkt. Kann jederzeit rückgängig gemacht werden. Alle Meldungen zu diesem Konto werden geschlossen.
+        suspend_description_html: Das Konto und alle Inhalte werden unzugänglich und ggf. gelöscht. Eine Interaktion mit dem Konto wird unmöglich. Dies kann innerhalb von 30 Tagen rückgängig gemacht werden. Alle Meldungen zu diesem Konto werden geschlossen.
+      actions_description_html: Entscheide, welche Maßnahmen du zum Klären dieser Meldung ergreifen möchtest. Wenn du eine Strafmaßnahme gegen das gemeldete Konto ergreifst, wird eine E-Mail-Benachrichtigung an dieses gesendet, außer wenn die <strong>Spam</strong>-Kategorie ausgewählt ist.
+      actions_description_remote_html: Entscheide, welche Maßnahmen du zum Klären dieser Meldung ergreifen möchtest. Dies wirkt sich lediglich darauf aus, wie <strong>dein</strong> Server mit diesem externen Konto kommuniziert und dessen Inhalt handhabt.
+      actions_no_posts: Diese Meldung enthält keine zu löschenden Beiträge
+      add_to_report: Meldung ergänzen
+      already_suspended_badges:
+        local: Auf diesem Server bereits gesperrt
+        remote: Auf dem anderen Server bereits gesperrt
+      are_you_sure: Bist du dir sicher?
+      assign_to_self: Mir zuweisen
+      assigned: Zugewiesene*r Moderator*in
+      by_target_domain: Domain des gemeldeten Kontos
+      cancel: Abbrechen
+      category: Kategorie
+      category_description_html: Der Grund, weshalb dieses Konto und/oder der Inhalt gemeldet worden ist, wird in der Kommunikation mit dem gemeldeten Konto erwähnt
+      comment:
+        none: Kein
+      comment_description_html: "%{name} ergänzte die Meldung um folgende Hinweis:"
+      confirm: Bestätigen
+      confirm_action: Maßnahme gegen @%{acct} bestätigen
+      created_at: Gemeldet
+      delete_and_resolve: Beiträge löschen
+      forwarded: Weitergeleitet
+      forwarded_replies_explanation: Diese Meldung stammt von einem externen Profil und betrifft einen externen Inhalt. Der Inhalt wurde an dich weitergeleitet, weil er eine Antwort auf ein bei dir registriertes Profil ist.
+      forwarded_to: Weitergeleitet an %{domain}
+      mark_as_resolved: Als geklärt markieren
+      mark_as_sensitive: Mit einer Inhaltswarnung versehen
+      mark_as_unresolved: Als ungeklärt markieren
+      no_one_assigned: Niemand
+      notes:
+        create: Notiz hinzufügen
+        create_and_resolve: Mit Notiz als geklärt markieren
+        create_and_unresolve: Mit Notiz wieder öffnen
+        delete: Löschen
+        placeholder: Bitte beschreibe, welche Maßnahmen bzw. Sanktionen ergriffen worden sind, und führe alles auf, was es Erwähnenswertes zu diesem Profil zu berichten gibt …
+        title: Notizen
+      notes_description_html: Notiz an dich und andere Moderator*innen hinterlassen
+      processed_msg: Meldung Nr. %{id} erfolgreich bearbeitet
+      quick_actions_description_html: 'Führe eine schnelle Aktion aus oder scrolle nach unten, um gemeldete Inhalte zu sehen:'
+      remote_user_placeholder: das externe Profil von %{instance}
+      reopen: Meldung wieder eröffnen
+      report: "%{id}. Meldung"
+      reported_account: Gemeldetes Konto
+      reported_by: Gemeldet von
+      reported_with_application: Per App gemeldet
+      resolved: Geklärt
+      resolved_msg: Meldung erfolgreich geklärt!
+      skip_to_actions: Zur Maßnahme springen
+      status: Status
+      statuses: Gemeldeter Inhalt
+      statuses_description_html: Beanstandete Inhalte werden in der Kommunikation mit dem gemeldeten Konto erwähnt
+      summary:
+        action_preambles:
+          delete_html: 'Du bist dabei, einige Beiträge von <strong>@%{acct}</strong> zu <strong>entfernen</strong>. Dies wird:'
+          mark_as_sensitive_html: 'Du bist dabei, einige Beiträge von <strong>@%{acct}</strong> mit einer <strong>Inhaltswarnung</strong> zu <strong>versehen</strong>. Dies wird:'
+          silence_html: 'Du bist dabei, das Konto von <strong>@%{acct}</strong> <strong>einzuschränken</strong>. Dies wird:'
+          suspend_html: 'Du bist dabei, das Konto von <strong>@%{acct}</strong> zu <strong>sperren</strong>. Dies wird:'
+        actions:
+          delete_html: Die beanstandeten Beiträge entfernen
+          mark_as_sensitive_html: Medien der beanstandeten Beiträge mit einer Inhaltswarnung versehen
+          silence_html: Schränkt die Reichweite von <strong>@%{acct}</strong> stark ein, indem das Profil und dessen Inhalte nur für Personen sichtbar sind, die dem Profil bereits folgen oder es manuell aufrufen
+          suspend_html: "<strong>@%{acct}</strong> sperren, sodass das Profil und dessen Inhalte nicht mehr zugänglich sind und keine Interaktion mehr möglich ist"
+        close_report: Meldung Nr. %{id} als geklärt markieren
+        close_reports_html: "<strong>Alle</strong> Meldungen gegen <strong>@%{acct}</strong> als geklärt markieren"
+        delete_data_html: Das Profil und die Inhalte von <strong>@%{acct}</strong> in 30 Tagen löschen, es sei denn, das Konto wird in der Zwischenzeit entsperrt
+        preview_preamble_html: "<strong>@%{acct}</strong> wird eine Warnung mit folgenden Inhalten erhalten:"
+        record_strike_html: Einen Verstoß gegen <strong>@%{acct}</strong> vermerken, um bei zukünftigen Verstößen desselben Kontos besser reagieren zu können
+        send_email_html: "<strong>@%{acct}</strong> eine Warnung per E-Mail senden"
+        warning_placeholder: "(Optional) Zusätzliche Begründung für die Moderationsaktion."
+      target_origin: Domain des gemeldeten Kontos
+      title: Meldungen
+      unassign: Zuweisung aufheben
+      unknown_action_msg: 'Unbekannte Aktion: %{action}'
+      unresolved: Ungeklärt
+      updated_at: Aktualisiert
+      view_profile: Profil anzeigen
+    roles:
+      add_new: Rolle hinzufügen
+      assigned_users:
+        one: "%{count} Konto"
+        other: "%{count} Konten"
+      categories:
+        administration: Administration
+        devops: DevOps
+        invites: Einladungen
+        moderation: Moderation
+        special: Besonderheit
+      delete: Entfernen
+      description_html: Mit <strong>Rollen</strong> kannst du die Funktionen und Bereiche von Mastodon anpassen, auf die deine Benutzer*innen zugreifen können.
+      edit: Rolle „%{name}“ bearbeiten
+      everyone: Standard
+      everyone_full_description_html: Das ist die <strong>Basis-Rolle</strong>, die für <strong>alle Benutzer*innen</strong> gilt – auch für diejenigen ohne zugewiesene Rolle. Alle anderen Rollen erben Berechtigungen davon.
+      permissions_count:
+        one: "%{count} Berechtigung"
+        other: "%{count} Berechtigungen"
+      privileges:
+        administrator: Administrator*in
+        administrator_description: Benutzer*innen mit dieser Berechtigung werden alle Beschränkungen umgehen
+        delete_user_data: Kontodaten löschen
+        delete_user_data_description: Erlaubt Benutzer*innen, die Daten anderer Benutzer*innen sofort zu löschen
+        invite_users: Leute einladen
+        invite_users_description: Erlaubt bereits registrierten Benutzer*innen, neue Leute zum Server einzuladen
+        manage_announcements: Ankündigungen verwalten
+        manage_announcements_description: Erlaubt Profilen, Ankündigungen auf dem Server zu verwalten
+        manage_appeals: Einsprüche verwalten
+        manage_appeals_description: Erlaubt es Benutzer*innen, Entscheidungen der Moderator*innen zu widersprechen
+        manage_blocks: Sperrungen verwalten
+        manage_blocks_description: Erlaubt Nutzer*innen das Sperren von E-Mail-Anbietern und IP-Adressen
+        manage_custom_emojis: Eigene Emojis verwalten
+        manage_custom_emojis_description: Erlaubt es Benutzer*innen, eigene Emojis auf dem Server zu verwalten
+        manage_federation: Föderation verwalten
+        manage_federation_description: Erlaubt Benutzer*innen, Domains anderer Mastodon-Server zu sperren oder zuzulassen – und die Zustellbarkeit zu steuern
+        manage_invites: Einladungen verwalten
+        manage_invites_description: Erlaubt es Benutzer*innen, Einladungslinks zu durchsuchen und zu deaktivieren
+        manage_reports: Meldungen verwalten
+        manage_reports_description: Erlaubt es Benutzer*innen, Meldungen zu überprüfen und Vorfälle zu moderieren
+        manage_roles: Rollen verwalten
+        manage_roles_description: Erlaubt es Benutzer*innen, Rollen, die sich unterhalb der eigenen Rolle befinden, zu verwalten und zuzuweisen
+        manage_rules: Serverregeln verwalten
+        manage_rules_description: Erlaubt es Benutzer*innen, Serverregeln zu ändern
+        manage_settings: Einstellungen verwalten
+        manage_settings_description: Erlaubt Nutzer*innen, Einstellungen dieses Servers zu ändern
+        manage_taxonomies: Hashtags verwalten
+        manage_taxonomies_description: Ermöglicht Benutzer*innen, die Trends zu überprüfen und die Hashtag-Einstellungen zu aktualisieren
+        manage_user_access: Kontozugriff verwalten
+        manage_user_access_description: Erlaubt Nutzer*innen, die Zwei-Faktor-Authentisierung anderer zu deaktivieren, ihre E-Mail-Adresse zu ändern und ihr Passwort zurückzusetzen
+        manage_users: Konten verwalten
+        manage_users_description: Erlaubt es Benutzer*innen, die Details anderer Profile einzusehen und diese Accounts zu moderieren
+        manage_webhooks: Webhooks verwalten
+        manage_webhooks_description: Erlaubt es Benutzer*innen, Webhooks für administrative Vorkommnisse einzurichten
+        view_audit_log: Audit-Log anzeigen
+        view_audit_log_description: Erlaubt es Benutzer*innen, den Verlauf der administrativen Handlungen auf diesem Server einzusehen
+        view_dashboard: Dashboard anzeigen
+        view_dashboard_description: Gewährt Benutzer*innen den Zugriff auf das Dashboard und verschiedene Metriken
+        view_devops: DevOps
+        view_devops_description: Erlaubt es Benutzer*innen, auf die Sidekiq- und pgHero-Dashboards zuzugreifen
+      title: Rollen
+    rules:
+      add_new: Regel hinzufügen
+      add_translation: Übersetzung hinzufügen
+      delete: Löschen
+      description_html: Während die meisten behaupten, die Nutzungsbedingungen tatsächlich gelesen zu haben, bekommen viele sie erst nach einem Problem mit. <strong>Vereinfache und reduziere daher die Serverregeln mit Stichpunkten.</strong> Versuche dabei, die einzelnen Vorgaben kurz und einfach zu halten, aber vermeide, sie in viele verschiedene Elemente aufzuteilen.
+      edit: Regel bearbeiten
+      empty: Es wurden bisher keine Serverregeln definiert.
+      move_down: Abwärts
+      move_up: Aufwärts
+      title: Serverregeln
+      translation: Übersetzung
+      translations: Übersetzungen
+      translations_explanation: Du kannst Serverregeln übersetzen. Der Standardwert wird angezeigt, wenn keine übersetzte Version verfügbar ist. Bitte vergewissere dich, dass jede Übersetzung mit dem Standardwert übereinstimmt.
+    settings:
+      about:
+        manage_rules: Serverregeln verwalten
+        preamble: Schildere ausführlich, wie dein Server betrieben, moderiert und finanziert wird.
+        rules_hint: Es gibt einen eigenen Bereich für Regeln, die deine Benutzer*innen einhalten müssen.
+        title: Über
+      allow_referrer_origin:
+        desc: Klicken Nutzer*innen auf Links zu externen Seiten, kann der Browser die Adresse deines Mastodon-Servers als Referrer (Verweis) übermitteln. Diese Option sollte deaktiviert werden, wenn Nutzer*innen dadurch eindeutig identifiziert würden – z. B. wenn es sich um einen privaten Mastodon-Server handelt.
+        title: Externen Seiten erlauben, diesen Mastodon-Server als Quelle zu sehen
+      appearance:
+        preamble: Passe das Webinterface von Mastodon an.
+        title: Design
+      branding:
+        preamble: Das Branding deines Servers unterscheidet ihn von anderen Servern im Netzwerk. Diese Informationen können in einer Vielzahl von Umgebungen angezeigt werden, z. B. in der Weboberfläche von Mastodon, in nativen Anwendungen, in Linkvorschauen auf anderen Websites und in Messaging-Apps und so weiter. Aus diesem Grund ist es am besten, diese Informationen klar, kurz und prägnant zu halten.
+        title: Branding
+      captcha_enabled:
+        desc_html: Dies beruht auf externen Skripten von hCaptcha, die ein Sicherheits- und Datenschutzproblem darstellen könnten. Darüber hinaus <strong>kann das den Registrierungsprozess für manche Menschen (insbesondere für Menschen mit Behinderung) erheblich erschweren</strong>. Aus diesen Gründen solltest du alternative Maßnahmen in Betracht ziehen, z. B. eine Registrierung basierend auf einer Einladung oder auf Genehmigungen.
+        title: Neue Nutzer*innen müssen ein CAPTCHA lösen, um das Konto zu bestätigen
+      content_retention:
+        danger_zone: Gefahrenzone
+        preamble: Lege fest, wie lange Inhalte von Nutzer*innen auf deinem Mastodon-Server gespeichert bleiben.
+        title: Cache & Archive
+      default_noindex:
+        desc_html: Betrifft alle Profile, die diese Einstellung bei sich nicht geändert haben
+        title: Profile standardmäßig von der Suchmaschinen-Indizierung ausnehmen
+      discovery:
+        follow_recommendations: Follower-Empfehlungen
+        preamble: Das Auffinden interessanter Inhalte ist wichtig, um neue Nutzer einzubinden, die Mastodon noch nicht kennen. Bestimme, wie verschiedene Suchfunktionen auf deinem Server funktionieren.
+        privacy: Datenschutz
+        profile_directory: Profilverzeichnis
+        public_timelines: Öffentliche Timeline
+        publish_statistics: Statistiken veröffentlichen
+        title: Entdecken
+        trends: Trends
+      domain_blocks:
+        all: Allen
+        disabled: Niemandem
+        users: Für angemeldete lokale Benutzer*innen
+      registrations:
+        moderation_recommandation: Bitte vergewissere dich, dass du ein geeignetes und reaktionsschnelles Moderationsteam hast, bevor du die Registrierungen uneingeschränkt zulässt!
+        preamble: Lege fest, wer auf deinem Server ein Konto erstellen darf.
+        title: Registrierungen
+      registrations_mode:
+        modes:
+          approved: Registrierung muss genehmigt werden
+          none: Niemand darf sich registrieren
+          open: Alle können sich registrieren
+        warning_hint: Wir empfehlen die Einstellung „Registrierung muss genehmigt werden“ zu verwenden, es sei denn, du bist dir sicher, dass dein Moderationsteam Spam und böswillige Registrierungen rechtzeitig bearbeiten kann.
+      security:
+        authorized_fetch: Authentisierung von föderierten Servern erforderlich machen
+        authorized_fetch_hint: Das Anfordern einer Authentisierung von föderierten Servern ermöglicht ein strengeres Durchsetzen von Sperren sowohl auf Ebene der Benutzer*innen als auch des Servers. Allerdings ist das mit Leistungseinbußen verbunden, reduziert die Reichweite deiner Antworten und kann zu Kompatibilitätsproblemen mit einigen föderierten Diensten führen. Darüber hinaus wird das Abrufen deiner öffentlichen Beiträge und Konten durch spezialisierte Akteur*innen nicht verhindert.
+        authorized_fetch_overridden_hint: Diese Einstellung wird derzeit von einer Umgebungsvariable überschrieben und kann daher nicht geändert werden.
+        federation_authentication: Authentisierung von föderierten Servern durchsetzen
+      title: Servereinstellungen
+    site_uploads:
+      delete: Hochgeladene Datei löschen
+      destroyed_msg: Upload erfolgreich gelöscht!
+    software_updates:
+      critical_update: Kritisch — bitte zügig aktualisieren
+      description: Es wird empfohlen, deine Mastodon-Installation auf dem aktuellen Stand zu halten, um von den neuesten Fehlerkorrekturen und Funktionen zu profitieren. Darüber hinaus ist es wichtig, Mastodon zeitnah zu aktualisieren, um Sicherheitslücken zu schließen. Aus diesen Gründen prüft Mastodon alle 30 Minuten auf Updates und du wirst deinen Einstellungen entsprechend per E-Mail informiert.
+      documentation_link: Mehr erfahren
+      release_notes: Versionshinweise
+      title: Verfügbare Updates
+      type: Art
+      types:
+        major: Hauptversion
+        minor: Nebenversion
+        patch: Revision — Fehlerkorrekturen und einfach zu implementierende Änderungen
+      version: Version
+    statuses:
+      account: Autor*in
+      application: Anwendung
+      back_to_account: Zurück zum Konto
+      back_to_report: Zurück zur Seite mit den Meldungen
+      batch:
+        add_to_report: Der Meldung Nr. %{id} hinzufügen
+        remove_from_report: Von der Meldung entfernen
+        report: Meldung
+      contents: Inhalte
+      deleted: Gelöscht
+      favourites: Favoriten
+      history: Versionsverlauf
+      in_reply_to: Antwortet auf
+      language: Sprache
+      media:
+        title: Medien
+      metadata: Metadaten
+      no_history: Der Beitrag wurde nicht bearbeitet
+      no_status_selected: Keine Beiträge wurden geändert, weil keine ausgewählt wurden
+      open: Beitrag öffnen
+      original_status: Ursprünglicher Beitrag
+      reblogs: Geteilte Beiträge
+      replied_to_html: Antwortete %{acct_link}
+      status_changed: Beitrag bearbeitet
+      status_title: Beitrag von @%{name}
+      title: Beiträge des Kontos – @%{name}
+      trending: Trends
+      view_publicly: Öffentlich anzeigen
+      visibility: Sichtbarkeit
+      with_media: Mit Medien
+    strikes:
+      actions:
+        delete_statuses: "%{name} entfernte die Beiträge von %{target}"
+        disable: "%{name} fror das Konto von %{target} ein"
+        mark_statuses_as_sensitive: "%{name} hat die Beiträge von %{target} mit einer Inhaltswarnung versehen"
+        none: "%{name} hat eine Warnung an %{target} gesendet"
+        sensitive: "%{name} versah das Konto von %{target} mit einer Inhaltswarnung"
+        silence: "%{name} schaltete das Konto von %{target} stumm"
+        suspend: "%{name} sperrte das Konto von %{target}"
+      appeal_approved: Einspruch angenommen
+      appeal_pending: Einspruch ausstehend
+      appeal_rejected: Einspruch abgelehnt
+    system_checks:
+      database_schema_check:
+        message_html: Es gibt ausstehende Datenbankmigrationen. Bitte führe sie aus, um sicherzustellen, dass sich die Anwendung wie erwartet verhält
+      elasticsearch_analysis_index_mismatch:
+        message_html: 'Die Einstellungen für die Indexanalyse von Elasticsearch sind veraltet. Bitte führe diesen Code aus: <code>tootctl search deploy --only-mapping --only=%{value}</code>'
+      elasticsearch_health_red:
+        message_html: Elasticsearch-Cluster ist fehlerhaft (roter Status) – Suchfunktionen sind nicht verfügbar
+      elasticsearch_health_yellow:
+        message_html: Elasticsearch-Cluster ist fehlerhaft (gelber Status) – du solltest den Grund dafür untersuchen
+      elasticsearch_index_mismatch:
+        message_html: 'Elasticsearch-Index-Mappings sind veraltet. Bitte führe Folgendes aus: <code>tootctl search deploy --only=%{value}</code>'
+      elasticsearch_preset:
+        action: Dokumentation ansehen
+        message_html: Elasticsearch-Cluster besitzt mehr als einen Knoten, aber Mastodon ist nicht für die Verwendung dieser Knoten konfiguriert.
+      elasticsearch_preset_single_node:
+        action: Dokumentation ansehen
+        message_html: Elasticsearch-Cluster besitzt nur einen Knoten. <code>ES_PRESET</code> sollte auf <code>single_node_cluster</code> gesetzt werden.
+      elasticsearch_reset_chewy:
+        message_html: 'Elasticsearch-Systemindex ist aufgrund einer Einstellungsänderung veraltet. Bitte führe Folgendes zum Aktualisieren aus: <code>tootctl search deploy --reset-chewy</code>'
+      elasticsearch_running_check:
+        message_html: Verbindung mit Elasticsearch konnte nicht hergestellt werden. Bitte prüfe, ob Elasticsearch läuft, oder deaktiviere die Volltextsuche
+      elasticsearch_version_check:
+        message_html: 'Inkompatible Elasticsearch-Version: %{value}'
+        version_comparison: Elasticsearch %{running_version} läuft, aber %{required_version} wird benötigt
+      rules_check:
+        action: Serverregeln verwalten
+        message_html: Du hast keine Serverregeln festgelegt.
+      sidekiq_process_check:
+        message_html: Kein Sidekiq-Prozess läuft für die %{value} Warteschlange(n). Bitte überprüfe deine Sidekiq-Konfiguration
+      software_version_check:
+        action: Verfügbare Updates ansehen
+        message_html: Ein Mastodon-Update ist verfügbar.
+      software_version_critical_check:
+        action: Verfügbare Updates ansehen
+        message_html: Ein kritisches Mastodon-Update ist verfügbar – bitte aktualisiere so schnell wie möglich.
+      software_version_patch_check:
+        action: Verfügbare Updates ansehen
+        message_html: Ein Mastodon-Update für Fehlerkorrekturen ist verfügbar.
+      upload_check_privacy_error:
+        action: Für weitere Informationen hier klicken
+        message_html: "<strong>Die Konfiguration deines Servers ist fehlerhaft. Die Privatsphäre deiner Benutzer*innen ist gefährdet.</strong>"
+      upload_check_privacy_error_object_storage:
+        action: Für weitere Informationen hier klicken
+        message_html: "<strong>Die Konfiguration deines Objektspeichers ist fehlerhaft. Die Privatsphäre deiner Benutzer*innen ist gefährdet.</strong>"
+    tags:
+      moderation:
+        not_trendable: Nicht trendfähig
+        not_usable: Nicht verwendbar
+        pending_review: Überprüfung ausstehend
+        review_requested: Überprüfung angefordert
+        reviewed: Überprüft
+        title: Status
+        trendable: Trendfähig
+        unreviewed: Ungeprüft
+        usable: Verwendbar
+      name: Name
+      newest: Neueste
+      oldest: Älteste
+      open: Öffentlich anzeigen
+      reset: Zurücksetzen
+      review: Prüfstatus
+      search: Suchen
+      title: Hashtags
+      updated_msg: Hashtag-Einstellungen erfolgreich aktualisiert
+    terms_of_service:
+      back: Zurück zu den Nutzungsbedingungen
+      changelog: Was sich geändert hat
+      create: Eigene erstellen
+      current: Aktuell
+      draft: Entwurf
+      generate: Vorlage verwenden
+      generates:
+        action: Erstellen
+        chance_to_review_html: "<strong>Die durch diese Vorlage erstellten Nutzungsbedingungen werden nicht automatisch veröffentlicht.</strong> Du wirst alles noch einmal überprüfen können. Bitte fülle alle Felder mit den notwendigen Informationen aus, um fortzufahren."
+        explanation_html: Die Vorlage für die Nutzungsbedingungen dient ausschließlich zu Informationszwecken und sollte nicht als Rechtsberatung zu einem bestimmten Thema verstanden werden. Bei rechtlichen Fragen, konsultiere bitte deinen Rechtsbeistand.
+        title: Nutzungsbedingungen festlegen
+      going_live_on_html: Aktuell gültig (ab %{date})
+      history: Verlauf
+      live: Aktuell gültig
+      no_history: Es wurden noch keine Änderungen an den Nutzungsbedingungen aufgezeichnet.
+      no_terms_of_service_html: Du hast derzeit keine Nutzungsbedingungen bereitgestellt. Nutzungsbedingungen verschaffen Klarheit und schützen vor möglicher Haftung bei Streitigkeiten mit deinen Nutzer*innen.
+      notified_on_html: Nutzer*innen wurden am %{date} benachrichtigt
+      notify_users: Nutzer*innen benachrichtigen
+      preview:
+        explanation_html: 'Die E-Mail wird an <strong>%{display_count} Nutzer*innen</strong> gesendet, die sich vor dem %{date} registriert haben. Folgendes wird in der E-Mail enthalten sein:'
+        send_preview: Vorschau an %{email} senden
+        send_to_all:
+          one: "%{display_count} E-Mail senden"
+          other: "%{display_count} E-Mails senden"
+        title: Vorschau zu den neuen Nutzungsbedingungen
+      publish: Veröffentlichen
+      published_on_html: Veröffentlicht am %{date}
+      save_draft: Entwurf speichern
+      title: Nutzungsbedingungen
+    title: Administration
+    trends:
+      allow: Erlauben
+      approved: Freigegeben
+      confirm_allow: Möchtest du die ausgewählten Tags wirklich erlauben?
+      confirm_disallow: Möchtest du die ausgewählten Tags wirklich verbieten?
+      disallow: Verbieten
+      links:
+        allow: Link erlauben
+        allow_provider: Herausgeber*in erlauben
+        confirm_allow: Möchtest du die ausgewählten Links wirklich erlauben?
+        confirm_allow_provider: Möchtest du die ausgewählten Anbieter wirklich erlauben?
+        confirm_disallow: Möchtest du die ausgewählten Links wirklich verbieten?
+        confirm_disallow_provider: Möchtest du die ausgewählten Anbieter wirklich verbieten?
+        description_html: Dies sind Links, die derzeit von zahlreichen Konten geteilt werden und die deinem Server aufgefallen sind. Die Benutzer*innen können darüber herausfinden, was in der Welt vor sich geht. Die Links werden allerdings erst dann öffentlich vorgeschlagen, wenn du die Herausgeber*innen genehmigt hast. Du kannst alternativ aber auch nur einzelne URLs zulassen oder ablehnen.
+        disallow: Link verbieten
+        disallow_provider: Herausgeber*in verbieten
+        no_link_selected: Keine Links wurden geändert, da keine ausgewählt wurden
+        publishers:
+          no_publisher_selected: Keine Herausgeber*innen wurden geändert, da keine ausgewählt wurden
+        shared_by_over_week:
+          one: In den vergangenen 7 Tagen von einem Profil geteilt
+          other: In den vergangenen 7 Tagen von %{count} Profilen geteilt
+        title: Angesagte Links
+        usage_comparison: Heute %{today}-mal und gestern %{yesterday}-mal geteilt
+      not_allowed_to_trend: Darf nicht trenden
+      only_allowed: Nur Genehmigte
+      pending_review: Überprüfung ausstehend
+      preview_card_providers:
+        allowed: Links von diesem/dieser Herausgeber*in können im Trend liegen
+        description_html: Dies sind Domains, von denen Links oft auf deinem Server geteilt werden. Links werden nicht öffentlich trenden, es sei denn, die Domain des Links wird genehmigt. Deine Zustimmung (oder Ablehnung) erstreckt sich auf Subdomains.
+        rejected: Links von diesem/dieser Herausgeber*in werden nicht im Trend liegen
+        title: Herausgeber
+      rejected: Abgelehnt
+      statuses:
+        allow: Beitrag erlauben
+        allow_account: Profil erlauben
+        confirm_allow: Möchtest du die ausgewählten Status wirklich erlauben?
+        confirm_allow_account: Möchtest du die ausgewählten Konten wirklich erlauben?
+        confirm_disallow: Möchtest du die ausgewählten Status wirklich verbieten?
+        confirm_disallow_account: Möchtest du die ausgewählten Konten wirklich verbieten?
+        description_html: Dies sind Beiträge, von denen dein Server weiß, dass sie derzeit viel geteilt und favorisiert werden. Dies kann neuen und wiederkehrenden Personen helfen, weitere Profile zu finden, denen sie folgen können. Die Beiträge werden erst dann öffentlich angezeigt, wenn du die Person genehmigst und sie es zulässt, dass ihr Profil anderen vorgeschlagen wird. Du kannst auch einzelne Beiträge zulassen oder ablehnen.
+        disallow: Beitrag verbieten
+        disallow_account: Profil verweigern
+        no_status_selected: Die im Trend liegenden Beiträge wurden nicht geändert, da keine ausgewählt wurden
+        not_discoverable: Autor*in hat sich dafür entschieden, nicht entdeckt zu werden
+        shared_by:
+          one: Einmal geteilt oder favorisiert
+          other: "%{friendly_count}-mal geteilt oder favorisiert"
+        title: Angesagte Beiträge
+      tags:
+        current_score: 'Aktueller Score: %{score}'
+        dashboard:
+          tag_accounts_measure: Profile
+          tag_languages_dimension: Häufigste Sprachen
+          tag_servers_dimension: Aktivste Server
+          tag_servers_measure: Server
+          tag_uses_measure: insgesamt
+        description_html: Diese Hashtags werden derzeit in vielen Beiträgen verwendet, die dein Server sieht. Dies kann deinen Nutzer*innen helfen, herauszufinden, worüber die Leute im Moment am meisten schreiben. Hashtags werden erst dann öffentlich angezeigt, wenn du sie genehmigst.
+        listable: Kann vorgeschlagen werden
+        no_tag_selected: Keine Hashtags wurden geändert, da keine ausgewählt wurden
+        not_listable: Wird nicht vorgeschlagen
+        not_trendable: Wird in den Trends nicht angezeigt
+        not_usable: Kann nicht verwendet werden
+        peaked_on_and_decaying: In den Trends am %{date}, jetzt absteigend
+        title: Angesagte Hashtags
+        trendable: Darf in den Trends erscheinen
+        trending_rank: Platz %{rank}
+        usable: Darf verwendet werden
+        usage_comparison: Heute %{today}-mal und gestern %{yesterday}-mal verwendet
+        used_by_over_week:
+          one: In den vergangenen 7 Tagen von einem Profil verwendet
+          other: In den vergangenen 7 Tagen von %{count} Profilen verwendet
+      title: Empfehlungen & Trends
+      trending: Angesagt
+    username_blocks:
+      add_new: Neue Regel
+      block_registrations: Registrierungen sperren
+      comparison:
+        contains: Enthält
+        equals: Entspricht
+      contains_html: Enthält %{string}
+      created_msg: Regel für Profilnamen erfolgreich erstellt
+      delete: Löschen
+      edit:
+        title: Regel für Profilnamen bearbeiten
+      matches_exactly_html: Entspricht %{string}
+      new:
+        create: Regel erstellen
+        title: Neue Regel für Profilnamen erstellen
+      no_username_block_selected: Keine Regeln für Profilnamen wurden geändert, weil keine ausgewählt wurde(n)
+      not_permitted: Nicht gestattet
+      title: Regeln für Profilnamen
+      updated_msg: Regel für Profilnamen erfolgreich aktualisiert
+    warning_presets:
+      add_new: Neu hinzufügen
+      delete: Löschen
+      edit_preset: Warnvorlage bearbeiten
+      empty: Du hast noch keine Warnvorlagen hinzugefügt.
+      title: Warnvorlagen
+    webhooks:
+      add_new: Endpunkt hinzufügen
+      delete: Löschen
+      description_html: Ein <strong>Webhook</strong> ermöglicht Mastodon, <strong>Echtzeitbenachrichtigungen</strong> über ausgewählte Ereignisse an deine eigene Anwendung zu senden, damit deine Anwendung <strong>automatisch Reaktionen auslösen kann</strong>.
+      disable: Deaktivieren
+      disabled: Deaktiviert
+      edit: Endpunkt bearbeiten
+      empty: Du hast noch keine Webhook-Endpunkte konfiguriert.
+      enable: Aktivieren
+      enabled: Aktiv
+      enabled_events:
+        one: 1 aktiviertes Ereignis
+        other: "%{count} aktivierte Ereignisse"
+      events: Ereignisse
+      new: Neuer Webhook
+      rotate_secret: Geheimen Schlüssel rotieren
+      secret: Signaturgeheimnis
+      status: Status
+      title: Webhooks
+      webhook: Webhook
+  admin_mailer:
+    auto_close_registrations:
+      body: Aufgrund fehlender Aktivität von Moderator*innen müssen neue Registrierungen auf %{instance} jetzt manuell genehmigt werden. Dies wurde automatisch umgestellt, damit %{instance} nicht als Plattform für Böswillige missbraucht werden kann. Du kannst jederzeit auf uneingeschränkte Registrierungen zurückwechseln.
+      subject: Registrierungen auf %{instance} müssen ab jetzt manuell genehmigt werden (automatisch umgestellt)
+    new_appeal:
+      actions:
+        delete_statuses: das Löschen der Beiträge
+        disable: das Einfrieren der Konten
+        mark_statuses_as_sensitive: um die Beiträge des Profils mit einer Inhaltswarnung zu versehen
+        none: eine Warnung
+        sensitive: das Markieren des Kontos mit einer Inhaltswarnung
+        silence: das Beschränken des Kontos
+        suspend: um deren Konto zu sperren
+      body: "%{target} erhebt Einspruch gegen eine Moderationsentscheidung von %{action_taken_by} vom %{date} (%{type}). Folgendes wurde geschrieben:"
+      next_steps: Du kannst dem Einspruch zustimmen, um die Moderationsentscheidung rückgängig zu machen, oder ihn ignorieren.
+      subject: "%{username} hat Einspruch gegen eine Moderationsentscheidung auf %{instance} erhoben"
+    new_critical_software_updates:
+      body: ein neues Sicherheitsupdate wurde veröffentlicht. Du solltest Mastodon so schnell wie möglich aktualisieren!
+      subject: Kritische Mastodon-Updates sind für %{instance} verfügbar!
+    new_pending_account:
+      body: Die Details von diesem neuem Konto sind unten. Du kannst die Anfrage akzeptieren oder ablehnen.
+      subject: Neues Konto zum Überprüfen auf %{instance} verfügbar (%{username})
+    new_report:
+      body: "%{reporter} hat %{target} gemeldet"
+      body_remote: Jemand von %{domain} hat %{target} gemeldet
+      subject: Neue Meldung auf %{instance} (Nr. %{id})
+    new_software_updates:
+      body: Neue Mastodon-Versionen wurden veröffentlicht – du solltest aktualisieren!
+      subject: Neue Mastodon-Versionen sind für %{instance} verfügbar!
+    new_trends:
+      body: 'Die folgenden Einträge müssen überprüft werden, bevor sie öffentlich angezeigt werden können:'
+      new_trending_links:
+        title: Angesagte Links
+      new_trending_statuses:
+        title: Angesagte Beiträge
+      new_trending_tags:
+        title: Angesagte Hashtags
+      subject: Neue Trends zur Überprüfung auf %{instance}
+  aliases:
+    add_new: Alias erstellen
+    created_msg: Neuer Alias erfolgreich erstellt. Du kannst nun den Umzug vom alten zum neuen Konto starten.
+    deleted_msg: Der Alias wurde erfolgreich entfernt. Aus jenem Konto zu diesem zu verschieben, ist nicht mehr möglich.
+    empty: Du hast keine Aliasse.
+    hint_html: Wenn du von einem anderen Konto auf dieses umziehen möchtest, dann kannst du hier einen Alias erstellen, der erforderlich ist, um deine Follower vom alten Konto auf dieses zu migrieren. Diese Aktion ist <strong>harmlos und wi­der­ruf­lich</strong>. <strong>Der Kontoumzug wird vom alten Konto aus eingeleitet</strong>.
+    remove: Alle Aliasse aufheben
+  appearance:
+    advanced_web_interface: Erweitertes Webinterface
+    advanced_web_interface_hint: Wenn du mehr aus deiner Bildschirmbreite herausholen möchtest, kannst du mit dem erweiterten Webinterface weitere Spalten hinzufügen und dadurch mehr Informationen auf einmal sehen, z. B. deine Startseite, die Benachrichtigungen, die föderierte Timeline sowie beliebig viele deiner Listen und Hashtags.
+    animations_and_accessibility: Animationen und Barrierefreiheit
+    confirmation_dialogs: Bestätigungsdialoge
+    discovery: Entdecken
+    localization:
+      body: Mastodon wird von Freiwilligen übersetzt.
+      guide_link: https://de.crowdin.com/project/mastodon/de
+      guide_link_text: Alle können mitmachen und etwas dazu beitragen.
+    sensitive_content: Inhaltswarnung
+  application_mailer:
+    notification_preferences: E-Mail-Einstellungen ändern
+    salutation: "%{name},"
+    settings: 'E-Mail-Einstellungen ändern: %{link}'
+    unsubscribe: Abbestellen
+    view: 'Siehe:'
+    view_profile: Profil anzeigen
+    view_status: Beitrag anschauen
+  applications:
+    created: Anwendung erfolgreich erstellt
+    destroyed: Anwendung erfolgreich gelöscht
+    logout: Abmelden
+    regenerate_token: Zugriffstoken neu erstellen
+    token_regenerated: Zugriffstoken erfolgreich neu erstellt
+    warning: Sei mit diesen Daten sehr vorsichtig. Teile sie mit niemandem!
+    your_token: Dein Zugriffstoken
+  auth:
+    apply_for_account: Konto beantragen
+    captcha_confirmation:
+      help_html: Falls du Probleme beim Lösen des CAPTCHA hast, dann kannst uns über %{email} kontaktieren und wir werden versuchen, dir zu helfen.
+      hint_html: Fast geschafft! Wir müssen uns vergewissern, dass du ein Mensch bist (damit wir Spam verhindern können!). Bitte löse das CAPTCHA und klicke auf „Fortfahren“.
+      title: Sicherheitsüberprüfung
+    confirmations:
+      awaiting_review: Deine E-Mail-Adresse wurde bestätigt und das Team von %{domain} überprüft nun deine Registrierung. Sobald es dein Konto genehmigt, wirst du eine E-Mail erhalten!
+      awaiting_review_title: Deine Registrierung wird überprüft
+      clicking_this_link: Klick auf diesen Link
+      login_link: anmelden
+      proceed_to_login_html: Du kannst dich nun %{login_link}.
+      redirect_to_app_html: Du hättest zur <strong>%{app_name}</strong>-App weitergeleitet werden sollen. Wenn das nicht geschehen ist, versuche es mit einem %{clicking_this_link} oder kehre manuell zur App zurück.
+      registration_complete: Deine Registrierung auf %{domain} ist nun abgeschlossen!
+      welcome_title: Willkommen, %{name}!
+      wrong_email_hint: Wenn diese E-Mail-Adresse nicht korrekt ist, kann sie in den Kontoeinstellungen geändert werden.
+    delete_account: Konto löschen
+    delete_account_html: Falls du dein Konto endgültig löschen möchtest, kannst du das <a href="%{path}">hier vornehmen</a>. Du musst dies zusätzlich bestätigen.
+    description:
+      prefix_invited_by_user: "@%{name} lädt dich ein, diesem Mastodon-Server beizutreten!"
+      prefix_sign_up: Registriere dich noch heute bei Mastodon!
+      suffix: Mit einem Konto kannst du Profilen folgen, neue Beiträge veröffentlichen, Nachrichten mit Personen von jedem Mastodon-Server austauschen und vieles mehr!
+    didnt_get_confirmation: Keinen Bestätigungslink erhalten?
+    dont_have_your_security_key: Du hast keinen Sicherheitsschlüssel?
+    forgot_password: Passwort vergessen?
+    invalid_reset_password_token: Das Token zum Zurücksetzen des Passworts ist ungültig oder abgelaufen. Bitte fordere ein neues an.
+    link_to_otp: Gib einen Zwei-Faktor-Code von deinem Smartphone oder einen Wiederherstellungscode ein
+    link_to_webauth: Verwende deinen Sicherheitsschlüssel
+    log_in_with: Anmelden mit
+    login: Anmelden
+    logout: Abmelden
+    migrate_account: Zu einem anderen Konto umziehen
+    migrate_account_html: Wenn du dieses Konto auf ein anderes weiterleiten möchtest, kannst du es <a href="%{path}">hier konfigurieren</a>.
+    or_log_in_with: Oder anmelden mit
+    progress:
+      confirm: E-Mail bestätigen
+      details: Deine Daten
+      review: Unsere Überprüfung
+      rules: Regeln akzeptieren
+    providers:
+      cas: CAS
+      saml: SAML
+    register: Registrieren
+    registration_closed: "%{instance} akzeptiert keine neuen Mitglieder"
+    resend_confirmation: Bestätigungslink erneut zusenden
+    reset_password: Passwort zurücksetzen
+    rules:
+      accept: Akzeptieren
+      back: Zurück
+      invited_by: 'Du kannst %{domain} beitreten – dank der Einladung von:'
+      preamble: Diese werden von den Moderator*innen von %{domain} festgelegt und durchgesetzt.
+      preamble_invited: Bevor du fortfährst, beachte bitte die Grundregeln der Moderator*innen von %{domain}.
+      title: Einige Grundregeln.
+      title_invited: Du wurdest eingeladen.
+    security: Sicherheit
+    set_new_password: Neues Passwort einrichten
+    setup:
+      email_below_hint_html: Überprüfe deinen Spam-Ordner oder lass dir den Bestätigungslink erneut zusenden. Falls die angegebene E-Mail-Adresse falsch ist, kannst du sie auch korrigieren.
+      email_settings_hint_html: Klicke auf den Link, den wir an %{email} gesendet haben, um mit Mastodon loszulegen. Wir warten hier solange auf dich.
+      link_not_received: Keinen Bestätigungslink erhalten?
+      new_confirmation_instructions_sent: In wenigen Minuten wirst du eine neue E-Mail mit dem Bestätigungslink erhalten!
+      title: Überprüfe dein E-Mail-Postfach
+    sign_in:
+      preamble_html: Melde dich mit deinen Zugangsdaten für <strong>%{domain}</strong> an. Falls dein Konto auf einem anderen Server erstellt wurde, ist eine Anmeldung hier nicht möglich.
+      title: Bei %{domain} anmelden
+    sign_up:
+      manual_review: Registrierungen für den Server %{domain} werden manuell durch unsere Moderator*innen überprüft. Um uns dabei zu unterstützen, schreibe etwas über dich und sage uns, weshalb du ein Konto auf %{domain} anlegen möchtest.
+      preamble: Mit einem Konto auf diesem Mastodon-Server kannst du jeder anderen Person im Fediverse folgen, unabhängig davon, wo ihr Konto registriert ist.
+      title: Lass uns dein Konto auf %{domain} einrichten.
+    status:
+      account_status: Kontostatus
+      confirming: Auf die Bestätigung deiner E-Mail-Adresse wird gewartet.
+      functional: Dein Konto ist voll funktionsfähig.
+      pending: Die Prüfung deiner Bewerbung steht noch aus und kann einige Zeit in Anspruch nehmen. Sobald deine Bewerbung genehmigt wurde, erhältst du eine E-Mail.
+      redirecting_to: Dein Konto ist inaktiv, weil es zu %{acct} umgezogen ist.
+      self_destruct: Da %{domain} den Betrieb einstellen wird, wirst du nur begrenzten Zugriff auf dein Konto haben.
+      view_strikes: Vorherige Verstöße deines Kontos ansehen
+    too_fast: Formular zu schnell übermittelt. Bitte versuche es erneut.
+    use_security_key: Sicherheitsschlüssel verwenden
+    user_agreement_html: Ich stimme den <a href="%{terms_of_service_path}" target="_blank">Nutzungsbedingungen</a> sowie der <a href="%{privacy_policy_path}" target="_blank">Datenschutzerklärung</a> zu
+    user_privacy_agreement_html: Ich stimme der <a href="%{privacy_policy_path}" target="_blank">Datenschutzerklärung</a> zu
+  author_attribution:
+    example_title: Beispieltitel
+    hint_html: Schreibst du außerhalb von Mastodon journalistische Artikel oder andere Texte, beispielsweise in einem Blog? Lege hier fest, wann auf dein Profil verwiesen werden soll, wenn Links zu deinen Werken auf Mastodon geteilt werden.
+    instructions: 'Der nachfolgende Code muss im HTML-Header deines zu verlinkenden Textes stehen:'
+    more_from_html: Mehr von %{name}
+    s_blog: Blog von %{name}
+    then_instructions: Ergänze anschließend im unteren Feld die Domain, auf der sich deine Inhalte befinden.
+    title: Verifizierung als Autor*in
+  challenge:
+    confirm: Fortfahren
+    hint_html: "<strong>Hinweis:</strong> Wir werden dich für die nächste Stunde nicht erneut nach deinem Passwort fragen."
+    invalid_password: Ungültiges Passwort
+    prompt: Bestätige mit deinem Passwort, um fortzufahren
+  crypto:
+    errors:
+      invalid_key: ist kein gültiger Ed25519- oder Curve25519-Schlüssel
+  date:
+    formats:
+      default: "%d. %b %Y"
+      with_month_name: "%d. %B %Y"
+  datetime:
+    distance_in_words:
+      about_x_hours: "%{count} Std."
+      about_x_months: "%{count} Mon."
+      about_x_years: "%{count} J."
+      almost_x_years: "%{count} J."
+      half_a_minute: Gerade eben
+      less_than_x_minutes: "%{count} Min."
+      less_than_x_seconds: Gerade eben
+      over_x_years: "%{count} J."
+      x_days: "%{count} T."
+      x_minutes: "%{count} Min."
+      x_months: "%{count} Mon."
+      x_seconds: "%{count} Sek."
+  deletes:
+    challenge_not_passed: Die eingegebenen Informationen waren nicht korrekt
+    confirm_password: Gib dein derzeitiges Passwort ein, um deine Identität zu bestätigen
+    confirm_username: Gib deinen Profilnamen ein, um den Vorgang zu bestätigen
+    proceed: Konto löschen
+    success_msg: Dein Konto wurde erfolgreich gelöscht
+    warning:
+      before: 'Bevor du fortfährst, lies bitte diese Hinweise sorgfältig durch:'
+      caches: Inhalte, die von anderen Servern zwischengespeichert wurden, können fortbestehen
+      data_removal: Deine Beiträge und alle anderen Daten werden für immer entfernt
+      email_change_html: Du kannst <a href="%{path}">deine E-Mail-Adresse ändern</a>, ohne dein Konto zu löschen
+      email_contact_html: Wenn die Bestätigungs-E-Mail immer noch nicht ankam, kannst du eine E-Mail an <a href="mailto:%{email}">%{email}</a> senden, um weitere Hilfe zu erhalten
+      email_reconfirmation_html: Wenn du die Bestätigungs-E-Mail nicht erhalten hast, kannst du sie <a href="%{path}">erneut anfordern</a>
+      irreversible: Du wirst dein Konto nicht mehr wiederherstellen oder reaktivieren können
+      more_details_html: Weitere Details findest du in der <a href="%{terms_path}">Datenschutzerklärung</a>.
+      username_available: Dein Profilname wird wieder verfügbar sein
+      username_unavailable: Dein Profilname wird auch nach dem Löschen für andere nicht zugänglich sein
+  disputes:
+    strikes:
+      action_taken: Maßnahme
+      appeal: Einspruch
+      appeal_approved: Dieser Verstoß wurde erfolgreich angefochten und ist nicht mehr gültig
+      appeal_rejected: Der Einspruch wurde abgelehnt
+      appeal_submitted_at: Einspruch eingereicht
+      appealed_msg: Dein Einspruch wurde übermittelt. Wenn er angenommen wird, wirst du benachrichtigt.
+      appeals:
+        submit: Einspruch erheben
+      approve_appeal: Einspruch annehmen
+      associated_report: Zugehörige Meldung
+      created_at: Datum
+      description_html: Dies sind Maßnahmen, die gegen dein Konto ergriffen worden sind, und Warnungen, die dir die Mitarbeiter*innen von %{instance} gesendet haben.
+      recipient: Adressiert an
+      reject_appeal: Einspruch ablehnen
+      status: "%{id}. Beitrag"
+      status_removed: Beitrag bereits vom System entfernt
+      title: "%{action} vom %{date}"
+      title_actions:
+        delete_statuses: Beitragsentfernung
+        disable: Konto einfrieren
+        mark_statuses_as_sensitive: Beiträge mit einer Inhaltswarnung versehen
+        none: Warnung
+        sensitive: Profil mit einer Inhaltswarnung versehen
+        silence: Kontobeschränkung
+        suspend: Kontosperre
+      your_appeal_approved: Dein Einspruch wurde angenommen
+      your_appeal_pending: Du hast Einspruch erhoben
+      your_appeal_rejected: Dein Einspruch wurde abgelehnt
+  edit_profile:
+    basic_information: Allgemeine Informationen
+    hint_html: "<strong>Bestimme, was andere auf deinem öffentlichen Profil und neben deinen Beiträgen sehen können.</strong> Wenn du ein Profilbild festlegst und dein Profil vervollständigst, werden andere eher mit dir interagieren und dir folgen."
+    other: Andere
+  emoji_styles:
+    auto: Automatisch
+    native: Nativ
+    twemoji: Twemoji
+  errors:
+    '400': Die Anfrage, die du gestellt hast, war ungültig oder fehlerhaft.
+    '403': Dir fehlt die Berechtigung, diese Seite aufzurufen.
+    '404': Die Seite, nach der du gesucht hast, wurde nicht gefunden.
+    '406': Diese Seite ist im gewünschten Format nicht verfügbar.
+    '410': Die Seite, nach der du gesucht hast, existiert hier nicht mehr.
+    '422':
+      content: Sicherheitsüberprüfung fehlgeschlagen. Blockierst du Cookies?
+      title: Sicherheitsüberprüfung fehlgeschlagen
+    '429': Zu viele Anfragen
+    '500':
+      content: Wir bitten um Verzeihung, aber etwas ist bei uns schiefgegangen.
+      title: Diese Seite enthält einen Fehler
+    '503': Die Seite konnte wegen eines temporären Serverfehlers nicht angezeigt werden.
+    noscript_html: Bitte aktiviere JavaScript, um das Webinterface von Mastodon zu verwenden. Alternativ kannst du auch eine der <a href="%{apps_path}">nativen Apps</a> für Mastodon verwenden.
+  existing_username_validator:
+    not_found: kann lokale Konten mit diesem Profilnamen nicht finden
+    not_found_multiple: "%{usernames} konnten nicht gefunden werden"
+  exports:
+    archive_takeout:
+      date: Datum
+      download: Archiv jetzt herunterladen
+      hint_html: Du kannst ein Archiv deiner <strong>Beiträge, Listen, hochgeladenen Medien usw.</strong> anfordern. Die exportierten Daten werden im ActivityPub-Format gespeichert und können mit geeigneter Software ausgewertet und angezeigt werden. Du kannst alle 7 Tage ein Archiv erstellen lassen.
+      in_progress: Persönliches Archiv wird erstellt …
+      request: Dein Archiv anfordern
+      size: Dateigröße
+    blocks: Blockierte Profile
+    bookmarks: Lesezeichen
+    csv: CSV
+    domain_blocks: Blockierte Domains
+    lists: Listen
+    mutes: Stummgeschaltete Profile
+    storage: Medienspeicher
+  featured_tags:
+    add_new: Neuen hinzufügen
+    errors:
+      limit: Du hast bereits die maximale Anzahl an Hashtags erreicht
+    hint_html: "<strong>Präsentiere deine wichtigsten Hashtags auf deinem Profil.</strong> Vorgestellte Hashtags verschaffen einen Überblick über deine kreativen Werke und langfristigen Projekte. Sie werden gut sichtbar auf deinem Profil angezeigt und ermöglichen einen schnellen Zugriff auf deine eigenen Beiträge."
+  filters:
+    contexts:
+      account: Profile
+      home: Startseite und Listen
+      notifications: Benachrichtigungen
+      public: Öffentliche Timelines
+      thread: Private Erwähnungen
+    edit:
+      add_keyword: Schlagwort hinzufügen
+      keywords: Schlagwörter
+      statuses: Individuelle Beiträge
+      statuses_hint_html: Dieser Filter gilt für die Auswahl einzelner Beiträge, unabhängig davon, ob sie mit den unten aufgeführten Schlagwörtern übereinstimmen. <a href="%{path}">Beiträge überprüfen oder aus dem Filter entfernen</a>.
+      title: Filter bearbeiten
+    errors:
+      deprecated_api_multiple_keywords: Diese Parameter können von dieser Anwendung nicht geändert werden, da sie für mehr als ein Filterschlagwort gelten. Verwende eine aktuellere Anwendung oder das Webinterface.
+      invalid_context: Ungültiger oder fehlender Kontext übergeben
+    index:
+      contexts: Filter in %{contexts}
+      delete: Löschen
+      empty: Du hast noch keine Filter erstellt.
+      expires_in: Läuft ab in %{distance}
+      expires_on: Läuft am %{date} ab
+      keywords:
+        one: "%{count} Schlagwort"
+        other: "%{count} Schlagwörter"
+      statuses:
+        one: "%{count} Beitrag"
+        other: "%{count} Beiträge"
+      statuses_long:
+        one: "%{count} individueller Beitrag ausgeblendet"
+        other: "%{count} individuelle Beiträge ausgeblendet"
+      title: Filter
+    new:
+      save: Neuen Filter speichern
+      title: Neuen Filter hinzufügen
+    statuses:
+      back_to_filter: Zurück zu den Filtern
+      batch:
+        remove: Filter entfernen
+      index:
+        hint: Dieser Filter wird verwendet, um einzelne Beiträge unabhängig von anderen Kriterien auszuwählen. Du kannst mehr Beiträge zu diesem Filter über das Webinterface hinzufügen.
+        title: Gefilterte Beiträge
+  generic:
+    all: Alle
+    all_items_on_page_selected_html:
+      one: "<strong>%{count}</strong> Element auf dieser Seite ausgewählt."
+      other: Alle <strong>%{count}</strong> Elemente auf dieser Seite ausgewählt.
+    all_matching_items_selected_html:
+      one: "<strong>%{count}</strong> Element, das den Suchkriterien entspricht, ist ausgewählt."
+      other: Alle <strong>%{count}</strong> Elemente, die den Suchkriterien entsprechen, sind ausgewählt.
+    cancel: Abbrechen
+    changes_saved_msg: Änderungen erfolgreich gespeichert!
+    confirm: Bestätigen
+    copy: Kopieren
+    delete: Löschen
+    deselect: Alle abwählen
+    none: Keine
+    order_by: Sortieren nach
+    save_changes: Änderungen speichern
+    select_all_matching_items:
+      one: Wähle %{count} Element, das deinen Suchkriterien entspricht.
+      other: Wähle alle %{count} Elemente, die deinen Suchkriterien entsprechen.
+    today: heute
+    validation_errors:
+      one: Etwas ist noch nicht ganz richtig! Bitte korrigiere den Fehler
+      other: Etwas ist noch nicht ganz richtig! Bitte korrigiere %{count} Fehler
+  imports:
+    errors:
+      empty: Leere CSV-Datei
+      incompatible_type: Inkompatibel mit dem ausgewählten Importtyp
+      invalid_csv_file: 'Ungültige CSV-Datei. Fehler: %{error}'
+      over_rows_processing_limit: enthält mehr als %{count} Zeilen
+      too_large: Datei ist zu groß
+    failures: Fehler
+    imported: Importiert
+    mismatched_types_warning: Möglicherweise hast du den falschen Typ für diesen Import ausgewählt. Bitte überprüfe alles noch einmal.
+    modes:
+      merge: Zusammenführen
+      merge_long: Bestehende Datensätze beibehalten und neue hinzufügen
+      overwrite: Überschreiben
+      overwrite_long: Bestehende Datensätze durch neue ersetzen
+    overwrite_preambles:
+      blocking_html:
+        one: Du bist dabei, <strong>deine Liste blockierter Konten</strong> aus <strong>%{filename}</strong> durch bis zu <strong>%{count} Konto</strong> zu ersetzen.
+        other: Du bist dabei, <strong>deine Liste blockierter Konten</strong> aus <strong>%{filename}</strong> durch bis zu <strong>%{count} Konten</strong> zu ersetzen.
+      bookmarks_html:
+        one: Du bist dabei, <strong>deine Lesezeichen</strong> aus <strong>%{filename}</strong> durch bis zu <strong>%{count} Beitrag</strong> zu ersetzen.
+        other: Du bist dabei, <strong>deine Lesezeichen</strong> aus <strong>%{filename}</strong> durch bis zu <strong>%{count} Beiträge</strong> zu ersetzen.
+      domain_blocking_html:
+        one: Du bist dabei, <strong>deine Liste blockierter Domains</strong> aus <strong>%{filename}</strong> durch bis zu <strong>%{count} Domain</strong> zu ersetzen.
+        other: Du bist dabei, <strong>deine Liste blockierter Domains</strong> aus <strong>%{filename}</strong> durch bis zu <strong>%{count} Domains</strong> zu ersetzen.
+      following_html:
+        one: Du bist dabei, bis zu <strong>%{count} Konto</strong> aus <strong>%{filename}</strong> zu <strong>folgen</strong> und <strong>allen anderen zu entfolgen</strong>.
+        other: Du bist dabei, bis zu <strong>%{count} Konten</strong> aus <strong>%{filename}</strong> zu <strong>folgen</strong> und <strong>allen anderen zu entfolgen</strong>.
+      lists_html:
+        one: Du bist dabei, <strong>deine Listen</strong> mit dem Inhalt aus <strong>%{filename}</strong> zu <strong>ersetzen</strong>. Bis zu <strong>%{count} Konto</strong> wird zu neuen Listen hinzugefügt.
+        other: Du bist dabei, <strong>deine Listen</strong> mit dem Inhalt aus <strong>%{filename}</strong> zu <strong>ersetzen</strong>. Bis zu <strong>%{count} Konten</strong> wird zu neuen Listen hinzugefügt.
+      muting_html:
+        one: Du bist dabei, <strong>deine Liste mit einem stummgeschalteten Konto</strong> aus <strong>%{filename}</strong> durch bis zu <strong>%{count} Konto</strong> zu ersetzen.
+        other: Du bist dabei, <strong>deine Liste stummgeschalteter Konten</strong> aus <strong>%{filename}</strong> durch bis zu <strong>%{count} Konten</strong> zu ersetzen.
+    preambles:
+      blocking_html:
+        one: Du bist dabei, bis zu <strong>%{count} Konto</strong> aus <strong>%{filename}</strong> zu <strong>blockieren</strong>.
+        other: Du bist dabei, bis zu <strong>%{count} Konten</strong> aus <strong>%{filename}</strong> zu <strong>blockieren</strong>.
+      bookmarks_html:
+        one: Du bist dabei, bis zu <strong>%{count} Beitrag</strong> aus <strong>%{filename}</strong> zu deinen <strong>Lesezeichen hinzuzufügen</strong>.
+        other: Du bist dabei, bis zu <strong>%{count} Beiträge</strong> aus <strong>%{filename}</strong> zu deinen <strong>Lesezeichen hinzuzufügen</strong>.
+      domain_blocking_html:
+        one: Du bist dabei, bis zu <strong>%{count} Domain</strong> aus <strong>%{filename}</strong> zu <strong>blockieren</strong>.
+        other: Du bist dabei, bis zu <strong>%{count} Domains</strong> aus <strong>%{filename}</strong> zu <strong>blockieren</strong>.
+      following_html:
+        one: Du bist dabei, bis zu <strong>%{count} Konto</strong> aus <strong>%{filename}</strong> zu <strong>folgen</strong>.
+        other: Du bist dabei, bis zu <strong>%{count} Konten</strong> aus <strong>%{filename}</strong> zu <strong>folgen</strong>.
+      lists_html:
+        one: Du bist dabei, bis zu <strong>%{count} Konto</strong> aus <strong>%{filename}</strong> zu deinen <strong>Listen hinzuzufügen</strong>. Wenn es keine Listen gibt, zu denen etwas hinzugefügt werden kann, dann werden neue Listen erstellt.
+        other: Du bist dabei, bis zu <strong>%{count} Konten</strong> aus <strong>%{filename}</strong> zu deinen <strong>Listen hinzuzufügen</strong>. Wenn es keine Listen gibt, zu denen etwas hinzugefügt werden kann, dann werden neue Listen erstellt.
+      muting_html:
+        one: Du bist dabei, bis zu <strong>%{count} Konto</strong> aus <strong>%{filename} stummzuschalten</strong>.
+        other: Du bist dabei, bis zu <strong>%{count} Konten</strong> aus <strong>%{filename} stummzuschalten</strong>.
+    preface: Daten, die du von einem Mastodon-Server exportiert hast, kannst du hierher importieren. Das betrifft beispielsweise die Listen von Profilen, denen du folgst oder die du blockiert hast.
+    recent_imports: Zuletzt importiert
+    states:
+      finished: Fertig
+      in_progress: In Bearbeitung
+      scheduled: Geplant
+      unconfirmed: Unbestätigt
+    status: Status
+    success: Deine Daten wurden erfolgreich hochgeladen und werden in Kürze verarbeitet
+    time_started: Gestartet am
+    titles:
+      blocking: Blockierte Konten importieren
+      bookmarks: Lesezeichen importieren
+      domain_blocking: Blockierte Domains importieren
+      following: Gefolgte Konten importieren
+      lists: Listen importieren
+      muting: Stummgeschaltete Konten importieren
+    type: Importtyp
+    type_groups:
+      constructive: Folge ich & Lesezeichen
+      destructive: Blockierte & Stummgeschaltete
+    types:
+      blocking: Blockierte Profile
+      bookmarks: Lesezeichen
+      domain_blocking: Blockierte Domains
+      following: Folge ich
+      lists: Listen
+      muting: Stummgeschaltete Profile
+    upload: Datei importieren
+  invites:
+    delete: Deaktivieren
+    expired: Abgelaufen
+    expires_in:
+      '1800': 30 Minuten
+      '21600': 6 Stunden
+      '3600': 1 Stunde
+      '43200': 12 Stunden
+      '604800': 1 Woche
+      '86400': 1 Tag
+    expires_in_prompt: Nie
+    generate: Einladungslink erstellen
+    invalid: Diese Einladung ist ungültig
+    invited_by: 'Du wurdest eingeladen von:'
+    max_uses:
+      one: Eine Verwendung
+      other: "%{count} Verwendungen"
+    max_uses_prompt: Unbegrenzt
+    prompt: Erstelle Einladungen und teile die dazugehörigen Links, um anderen einen Zugang zu diesem Server zu gewähren
+    table:
+      expires_at: Läuft ab
+      uses: Verwendungen
+    title: Einladungen
+  lists:
+    errors:
+      limit: Du hast die maximale Anzahl an Listen erreicht
+  login_activities:
+    authentication_methods:
+      otp: Zwei-Faktor-Authentisierungs-App
+      password: Passwort
+      sign_in_token: E-Mail-Sicherheitscode
+      webauthn: Sicherheitsschlüssel
+    description_html: Wenn du verdächtige Aktivitäten bemerkst, die du nicht verstehst oder zuordnen kannst, solltest du dringend dein Passwort ändern und ungeachtet dessen die Zwei-Faktor-Authentisierung aktivieren.
+    empty: Kein Anmeldeverlauf verfügbar
+    failed_sign_in_html: Fehlgeschlagener Anmeldeversuch mit %{method} von %{ip} (%{browser})
+    successful_sign_in_html: Erfolgreiches Anmelden mit %{method} von %{ip} (%{browser})
+    title: Anmeldeverlauf
+  mail_subscriptions:
+    unsubscribe:
+      action: Ja, abbestellen
+      complete: Abbestellt
+      confirmation_html: Möchtest du %{type} für Mastodon auf %{domain} an deine E-Mail-Adresse %{email} wirklich abbestellen? Du kannst dies später in den Einstellungen <a href="%{settings_path}">Benachrichtigungen per E-Mail</a> rückgängig machen.
+      emails:
+        notification_emails:
+          favourite: E-Mail-Benachrichtigungen bei Favoriten
+          follow: E-Mail-Benachrichtigungen bei Followern
+          follow_request: E-Mail-Benachrichtigungen bei Follower-Anfragen
+          mention: E-Mail-Benachrichtigungen bei Erwähnungen
+          reblog: E-Mail-Benachrichtigungen bei geteilten Beiträgen
+      resubscribe_html: Falls du etwas irrtümlich abbestellt hast, kannst du das in den Einstellungen <a href="%{settings_path}">Benachrichtigungen per E-Mail</a> rückgängig machen.
+      success_html: Du wirst nicht länger %{type} für Mastodon auf %{domain} an deine E-Mail-Adresse %{email} erhalten.
+      title: Abbestellen
+  media_attachments:
+    validations:
+      images_and_video: Es kann kein Video an einen Beitrag angehängt werden, der bereits Bilder enthält
+      not_found: Medieninhalt(e) %{ids} nicht gefunden oder bereits an einen anderen Beitrag angehängt
+      not_ready: Dateien, die noch nicht verarbeitet wurden, können nicht angehängt werden. Versuche es gleich noch einmal!
+      too_many: Mehr als vier Dateien können nicht angehängt werden
+  migrations:
+    acct: umgezogen nach
+    cancel: Nicht mehr weiterleiten
+    cancel_explanation: Das Abbrechen der Weiterleitung wird dein aktuelles Konto erneut aktivieren, aber keine Follower zurückholen, die auf dieses Konto verschoben wurden.
+    cancelled_msg: Die Weiterleitung wurde erfolgreich beendet.
+    errors:
+      already_moved: ist das gleiche Konto, zu dem du bereits umgezogen bist
+      missing_also_known_as: ist kein Alias für dieses Konto
+      move_to_self: darf nicht das aktuelles Konto sein
+      not_found: konnte nicht gefunden werden
+      on_cooldown: Die Abklingzeit läuft gerade
+    followers_count: Anzahl der Follower zum Zeitpunkt des Umzugs
+    incoming_migrations: Von einem anderen Konto umziehen
+    incoming_migrations_html: Um von einem anderen Konto zu diesem umzuziehen, musst du zuerst ein <a href="%{path}">Konto-Alias erstellen</a>.
+    moved_msg: Dein Konto wird jetzt auf %{acct} weitergeleitet und deine Follower werden übertragen.
+    not_redirecting: Dein Konto wird derzeit nicht auf ein anderes Konto weitergeleitet.
+    on_cooldown: Du bist mit deinem Konto erst vor Kurzem umgezogen. Diese Funktion wird in %{count} Tagen wieder verfügbar sein.
+    past_migrations: Vorherige Umzüge
+    proceed_with_move: Follower übertragen
+    redirected_msg: Dein Konto wird nun zu %{acct} weitergeleitet.
+    redirecting_to: Dein Konto wird zu %{acct} weitergeleitet.
+    set_redirect: Weiterleitung einrichten
+    warning:
+      backreference_required: Das neue Konto muss zuerst auf das alte Konto verweisen
+      before: 'Bevor du fortfährst, lies bitte diese Hinweise sorgfältig durch:'
+      cooldown: Nach dem Umzug wird es eine Weile dauern, bis du erneut umziehen darfst
+      disabled_account: Dein altes Konto ist nur noch eingeschränkt verwendbar. Du kannst jedoch deine Daten exportieren und das Konto wieder reaktivieren.
+      followers: Alle Follower werden vom alten zum neuen Konto übertragen
+      only_redirect_html: Alternativ kannst du auch <a href="%{path}">nur eine Weiterleitung zu deinem neuen Konto</a> einrichten, ohne die Follower zu übertragen.
+      other_data: Keine anderen Daten werden automatisch zum neuen Konto übertragen
+      redirect: Dein altes Konto wird einen Hinweis erhalten, dass du umgezogen bist. Außerdem wird das Profil von Suchanfragen ausgeschlossen
+  moderation:
+    title: Moderation
+  move_handler:
+    carry_blocks_over_text: Dieses Konto ist von %{acct}, das du blockiert hast, umgezogen.
+    carry_mutes_over_text: Dieses Konto ist von %{acct}, das du stummgeschaltet hast, umgezogen.
+    copy_account_note_text: 'Dieses Konto ist von %{acct} umgezogen. Hier deine damals verfassten Notizen zum Profil:'
+  navigation:
+    toggle_menu: Menü ein-/ausblenden
+  notification_mailer:
+    admin:
+      report:
+        subject: "%{name} hat eine Meldung eingereicht"
+      sign_up:
+        subject: "%{name} registrierte sich"
+    favourite:
+      body: 'Dein Beitrag wurde von %{name} favorisiert:'
+      subject: "%{name} favorisierte deinen Beitrag"
+      title: Neue Favorisierung
+    follow:
+      body: "%{name} folgt dir jetzt!"
+      subject: "%{name} folgt dir jetzt"
+      title: Neuer Follower
+    follow_request:
+      action: Follower-Anfragen verwalten
+      body: "%{name} möchte dir folgen"
+      subject: 'Ausstehende Follower-Anfragen: %{name}'
+      title: Neue Follower-Anfrage
+    mention:
+      action: Antworten
+      body: 'Du wurdest von %{name} erwähnt:'
+      subject: "%{name} erwähnte dich"
+      title: Neue Erwähnung
+    poll:
+      subject: Eine Umfrage von %{name} ist beendet
+    quote:
+      body: 'Dein Beitrag wurde von %{name} zitiert:'
+      subject: "%{name} zitierte deinen Beitrag"
+      title: Neuer zitierter Beitrag
+    reblog:
+      body: 'Dein Beitrag wurde von %{name} geteilt:'
+      subject: "%{name} teilte deinen Beitrag"
+      title: Dein Beitrag wurde geteilt
+    status:
+      subject: "%{name} veröffentlichte gerade einen Beitrag"
+    update:
+      subject: "%{name} bearbeitete einen Beitrag"
+  notifications:
+    administration_emails: Admin-E-Mail-Benachrichtigungen
+    email_events: Benachrichtigungen per E-Mail
+    email_events_hint: 'Bitte die Ereignisse auswählen, für die du Benachrichtigungen per E-Mail erhalten möchtest:'
+  number:
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Mrd.
+          million: Mio.
+          quadrillion: Brd.
+          thousand: Tsd.
+          trillion: Bio.
+  otp_authentication:
+    code_hint: Gib den Code ein, den deine 2FA- bzw. TOTP-App generiert hat, um den Vorgang zu bestätigen
+    description_html: Wenn du die <strong>Zwei-Faktor-Authentisierung</strong> (2FA) mit einer Authentifizierungs-App deines Smartphones aktivierst, benötigst du neben dem regulären Passwort zusätzlich auch den zeitbasierten Code der 2FA-App, um dich anmelden zu können.
+    enable: Aktivieren
+    instructions_html: "<strong>Scanne diesen QR-Code mit einer beliebigen Authentisierungs-App (TOTP)</strong>. Diese App generiert dann zeitbasierte Codes, die du beim Anmelden zusätzlich zum regulären Passwort eingeben musst."
+    manual_instructions: Wenn du den QR-Code nicht einscannen kannst, sondern die Zahlenfolge manuell eingeben musst, ist hier der geheime Token für deine 2FA-App.
+    setup: Einrichten
+    wrong_code: Der eingegebene Code ist ungültig! Laufen Serverzeit und Gerätezeit synchron?
+  pagination:
+    newer: Neuer
+    next: Weiter
+    older: Älter
+    prev: Zurück
+    truncate: "&hellip;"
+  polls:
+    errors:
+      already_voted: An dieser Umfrage hast du bereits teilgenommen
+      duplicate_options: enthält doppelte Einträge
+      duration_too_long: liegt zu weit in der Zukunft
+      duration_too_short: ist zu früh
+      expired: Diese Umfrage ist bereits beendet
+      invalid_choice: Diese Auswahl existiert nicht
+      over_character_limit: darf nicht länger als %{max} Zeichen sein
+      self_vote: Du kannst an deinen eigenen Umfragen nicht selbst teilnehmen
+      too_few_options: muss mehr als ein Auswahlfeld enthalten
+      too_many_options: darf nicht mehr als %{max} Auswahlfelder enthalten
+    vote: Abstimmen
+  posting_defaults:
+    explanation: Diese Einstellungen werden standardmäßig für neue Beiträge verwendet. Du kannst sie auch beim Verfassen eines Beitrags individuell anpassen.
+  preferences:
+    other: Erweitert
+    posting_defaults: Standardeinstellungen für Beiträge
+    public_timelines: Öffentliche Timelines
+  privacy:
+    hint_html: "<strong>Bestimme selbst, wie dein Profil und deine Beiträge gefunden werden sollen.</strong> Zahlreiche Mastodon-Funktionen können dir für eine größere Reichweite behilflich sein. Nimm dir einen Moment Zeit, um diese Einstellungen zu überprüfen."
+    privacy: Datenschutz
+    privacy_hint_html: Bestimme, wie viele Informationen du für andere preisgeben möchtest. Viele Menschen entdecken interessante Profile und coole Apps, indem sie die Follower anderer Profile durchstöbern und die Apps sehen, über die Beiträge veröffentlicht wurden – möglicherweise möchtest du diese Informationen ausblenden.
+    reach: Reichweite
+    reach_hint_html: Bestimme, ob Profile dich entdecken und dir folgen dürfen. Möchtest du, dass deine Beiträge unter „Entdecken“ erscheinen? Möchtest du, dass andere dich in ihren Follower-Empfehlungen sehen? Möchtest du alle neuen Follower automatisch akzeptieren oder jeden einzelnen genehmigen?
+    search: Suche
+    search_hint_html: Bestimme, wie du entdeckt werden möchtest. Möchtest du, dass die Leute dich anhand deiner öffentlichen Beiträge finden können? Möchtest du, dass Menschen außerhalb von Mastodon dein Profil finden, wenn sie im Internet suchen? Bitte beachte, dass ein vollständiger Ausschluss aus allen Suchmaschinen für öffentlich zugängliche Informationen nicht garantiert werden kann.
+    title: Datenschutz und Reichweite
+  privacy_policy:
+    title: Datenschutzerklärung
+  reactions:
+    errors:
+      limit_reached: Limit für verschiedene Reaktionen erreicht
+      unrecognized_emoji: ist ein unbekanntes Emoji
+  redirects:
+    prompt: Wenn du diesem Link vertraust, dann klicke ihn an, um fortzufahren.
+    title: Du verlässt %{instance}.
+  relationships:
+    activity: Kontoaktivität
+    confirm_follow_selected_followers: Möchtest du den ausgewählten Followern folgen?
+    confirm_remove_selected_followers: Möchtest du die ausgewählten Follower wirklich entfernen?
+    confirm_remove_selected_follows: Möchtest du den ausgewählten Konten wirklich entfolgen?
+    dormant: Inaktiv
+    follow_failure: Einigen der ausgewählten Konten konnte nicht gefolgt werden.
+    follow_selected_followers: Ausgewählten Followern folgen
+    followers: Follower
+    following: Folge ich
+    invited: Eingeladen
+    last_active: Zuletzt aktiv
+    most_recent: Neueste
+    moved: Umgezogen
+    mutual: Gegenseitig
+    primary: Primär
+    relationship: Beziehung
+    remove_selected_domains: Alle Follower von den ausgewählten Domains entfernen
+    remove_selected_followers: Ausgewählten Followern entfolgen
+    remove_selected_follows: Ausgewählten Profilen entfolgen
+    status: Kontostatus
+  remote_follow:
+    missing_resource: Die erforderliche Weiterleitungs-URL für dein Konto konnte nicht gefunden werden
+  reports:
+    errors:
+      invalid_rules: verweist nicht auf gültige Serverregeln
+  rss:
+    content_warning: 'Inhaltswarnung:'
+    descriptions:
+      account: Öffentliche Beiträge von @%{acct}
+      tag: 'Öffentliche Beiträge mit dem Hashtag #%{hashtag}'
+  scheduled_statuses:
+    over_daily_limit: Du hast das Limit von %{limit} geplanten Beiträgen für heute erreicht
+    over_total_limit: Du hast das Limit für geplante Beiträge, das %{limit} beträgt, erreicht
+    too_soon: Datum muss in der Zukunft liegen
+  self_destruct:
+    lead_html: Bedauerlicherweise wird <strong>%{domain}</strong> den Betrieb für immer einstellen. Wenn du dort ein Konto angelegt hast, wirst du es nicht weiter verwenden können. Du kannst allerdings eine Sicherung deiner Daten anfordern.
+    title: Dieser Server wird den Betrieb einstellen
+  sessions:
+    activity: Letzte Aktivität
+    browser: Browser
+    browsers:
+      alipay: Alipay
+      blackberry: BlackBerry
+      chrome: Chrome
+      edge: Edge
+      electron: Electron
+      firefox: Firefox
+      generic: Unbekannter Browser
+      huawei_browser: Huawei Browser
+      ie: Internet Explorer
+      micro_messenger: MicroMessenger
+      nokia: Nokia S40 Ovi Browser
+      opera: Opera
+      otter: Otter
+      phantom_js: PhantomJS
+      qq: QQ Browser
+      safari: Safari
+      uc_browser: UC Browser
+      unknown_browser: Unbekannter Browser
+      weibo: Weibo
+    current_session: Aktuelle Sitzung
+    date: Datum
+    description: "%{browser} auf %{platform}"
+    explanation: Dies sind die Webbrowser, die derzeit mit deinem Mastodon-Konto verbunden sind.
+    ip: IP-Adresse
+    platforms:
+      adobe_air: Adobe Air
+      android: Android
+      blackberry: BlackBerry
+      chrome_os: ChromeOS
+      firefox_os: Firefox OS
+      ios: iOS
+      kai_os: KaiOS
+      linux: Linux
+      mac: macOS
+      unknown_platform: Unbekannte Plattform
+      windows: Windows
+      windows_mobile: Windows Mobile
+      windows_phone: Windows Phone
+    revoke: Widerrufen
+    revoke_success: Sitzung erfolgreich widerrufen
+    title: Sitzungen
+    view_authentication_history: Anmeldeverlauf deines Kontos anzeigen
+  settings:
+    account: Konto
+    account_settings: Kontoeinstellungen
+    aliases: Konto-Aliasse
+    appearance: Design
+    authorized_apps: Autorisierte Anwendungen
+    back: Zurück zu Mastodon
+    delete: Kontolöschung
+    development: Entwicklung
+    edit_profile: Profil bearbeiten
+    export: Exportieren
+    featured_tags: Vorgestellte Hashtags
+    import: Importieren
+    import_and_export: Importieren und exportieren
+    migrate: Kontoumzug
+    notifications: E-Mail-Benachrichtigungen
+    preferences: Einstellungen
+    profile: Öffentliches Profil
+    relationships: Follower und Folge ich
+    severed_relationships: Getrennte Beziehungen
+    statuses_cleanup: Automatische Löschung
+    strikes: Maßnahmen
+    two_factor_authentication: Zwei-Faktor-Authentisierung
+    webauthn_authentication: Sicherheitsschlüssel
+  severed_relationships:
+    download: Herunterladen (%{count})
+    event_type:
+      account_suspension: Kontosperre (%{target_name})
+      domain_block: Serversperre (%{target_name})
+      user_domain_block: Du hast %{target_name} blockiert
+    lost_followers: Verlorene Follower
+    lost_follows: Konten entfolgt
+    preamble: Möglicherweise verlierst du Follower und entfolgst Konten, wenn du eine Domain blockierst oder Moderator*innen externe Server sperren. Sollte das der Fall sein, wirst du eine Liste mit den getrennten Beziehungen herunterladen können. Dadurch kannst du die Änderungen einsehen oder die Liste auf einen anderen Server importieren.
+    purged: Informationen über diesen Server wurden von deinen Server-Administrator*innen entfernt.
+    type: Ereignis
+  statuses:
+    attached:
+      audio:
+        one: "%{count} Audiodatei"
+        other: "%{count} Audiodateien"
+      description: 'Angehängt: %{attached}'
+      image:
+        one: "%{count} Bild"
+        other: "%{count} Bilder"
+      video:
+        one: "%{count} Video"
+        other: "%{count} Videos"
+    boosted_from_html: Geteilt von %{acct_link}
+    content_warning: 'Inhaltswarnung: %{warning}'
+    default_language: Wie die Sprache des Webinterface
+    disallowed_hashtags:
+      one: 'enthält einen nicht-erlaubten Hashtag: %{tags}'
+      other: 'enthält nicht-erlaubte Hashtags: %{tags}'
+    edited_at_html: 'Bearbeitet: %{date}'
+    errors:
+      in_reply_not_found: Der Beitrag, auf den du antworten möchtest, scheint nicht zu existieren.
+      quoted_status_not_found: Der Beitrag, den du zitieren möchtest, scheint nicht zu existieren.
+    over_character_limit: Begrenzung von %{max} Zeichen überschritten
+    pin_errors:
+      direct: Beiträge, die nur für erwähnte Profile sichtbar sind, können nicht angeheftet werden
+      limit: Du hast bereits die maximale Anzahl an Beiträgen angeheftet
+      ownership: Du kannst nur eigene Beiträge anheften
+      reblog: Du kannst keine geteilten Beiträge anheften
+    quote_policies:
+      followers: Nur Follower
+      nobody: Nur von mir
+      public: Alle
+    title: "%{name}: „%{quote}“"
+    visibilities:
+      direct: Private Erwähnung
+      private: Nur Follower
+      private_long: Nur für deine Follower sichtbar
+      public: Öffentlich
+      public_long: Alle innerhalb und außerhalb von Mastodon
+      unlisted: Nicht gelistet
+      unlisted_long: Wird nicht in den Suchergebnissen, Trends oder öffentlichen Timelines von Mastodon angezeigt
+  statuses_cleanup:
+    enabled: Alte Beiträge automatisch entfernen
+    enabled_hint: Löscht automatisch deine Beiträge, sobald sie die angegebene Altersgrenze erreicht haben, es sei denn, sie entsprechen einer der unten angegebenen Ausnahmen
+    exceptions: Ausnahmen
+    explanation: Damit der Server nicht durch das Löschen von Beiträgen ausgebremst wird, wartet die Mastodon-Software, bis wenig(er) los ist. Deshalb könnten deine Beiträge ggf. erst einige Zeit nach Erreichen der Altersgrenze gelöscht werden.
+    ignore_favs: Favoriten ignorieren
+    ignore_reblogs: Geteilte Beiträge ignorieren
+    interaction_exceptions: Ausnahmen basierend auf Interaktionen
+    interaction_exceptions_explanation: Beachte, dass Beiträge nicht gelöscht werden, sobald deine Grenzwerte für Favoriten oder geteilte Beiträge einmal überschritten wurden – auch dann nicht, wenn diese Schwellenwerte mittlerweile nicht mehr erreicht werden.
+    keep_direct: Private Nachrichten behalten
+    keep_direct_hint: Löscht keinen deiner Beiträge, die nur für erwähnte Profile sichtbar sind
+    keep_media: Beiträge mit Medien behalten
+    keep_media_hint: Löscht keinen deiner Beiträge mit Medienanhängen
+    keep_pinned: Angeheftete Beiträge behalten
+    keep_pinned_hint: Löscht keinen deiner angehefteten Beiträge
+    keep_polls: Umfragen behalten
+    keep_polls_hint: Löscht keine deiner Umfragen
+    keep_self_bookmark: Als Lesezeichen markierte Beiträge behalten
+    keep_self_bookmark_hint: Löscht keinen deiner Beiträge, die du als Lesezeichen gesetzt hast
+    keep_self_fav: Favorisierte Beiträge behalten
+    keep_self_fav_hint: Löscht keinen deiner eigenen Beiträge, die du favorisiert hast
+    min_age:
+      '1209600': 2 Wochen
+      '15778476': 6 Monate
+      '2629746': 1 Monat
+      '31556952': 1 Jahr
+      '5259492': 2 Monate
+      '604800': 1 Woche
+      '63113904': 2 Jahre
+      '7889238': 3 Monate
+    min_age_label: Altersgrenze
+    min_favs: Behalte Beiträge, die häufiger favorisiert wurden als …
+    min_favs_hint: Löscht keine Beiträge, die mindestens so oft favorisiert worden sind. Lass das Feld leer, um alle Beiträge – unabhängig der Anzahl an Favoriten – zu löschen
+    min_reblogs: Behalte Beiträge, die häufiger geteilt wurden als …
+    min_reblogs_hint: Löscht keine Beiträge, die mindestens so oft geteilt worden sind. Lass das Feld leer, um alle Beiträge – unabhängig der Anzahl an geteilten Beiträgen – zu löschen
+  stream_entries:
+    sensitive_content: Inhaltswarnung
+  strikes:
+    errors:
+      too_late: Es ist zu spät, um gegen diese Maßnahme Einspruch zu erheben
+  tags:
+    does_not_match_previous_name: entspricht nicht dem vorherigen Namen
+  terms_of_service:
+    title: Nutzungsbedingungen
+  terms_of_service_interstitial:
+    future_preamble_html: Wir aktualisieren unsere Nutzungsbedingungen, die am <strong>%{date}</strong> in Kraft treten. Bitte lies dir die aktualisierten Bedingungen sorgfältig durch.
+    past_preamble_html: Wir haben unsere Nutzungsbedingungen seit deinem letzten Besuch geändert. Bitte lies dir die aktualisierten Bedingungen sorgfältig durch.
+    review_link: Nutzungsbedingungen lesen
+    title: Die Nutzungsbedingungen von %{domain} ändern sich
+  themes:
+    contrast: Mastodon (Hoher Kontrast)
+    default: Mastodon (Dunkel)
+    mastodon-light: Mastodon (Hell)
+    system: Automatisch (wie Betriebssystem)
+  time:
+    formats:
+      default: "%d. %b %Y, %H:%M Uhr"
+      month: "%b %Y"
+      time: "%H:%M Uhr"
+      with_time_zone: "%d. %b %Y, %H:%M Uhr %Z"
+  translation:
+    errors:
+      quota_exceeded: Das Kontingent, das dem Server zur Verfügung steht, wurde für den Übersetzungsdienst überschritten.
+      too_many_requests: Der Übersetzungsdienst hat kürzlich zu viele Anfragen erhalten.
+  two_factor_authentication:
+    add: Hinzufügen
+    disable: Zwei-Faktor-Authentisierung deaktivieren
+    disabled_success: Zwei-Faktor-Authentisierung erfolgreich deaktiviert
+    edit: Bearbeiten
+    enabled: Zwei-Faktor-Authentisierung (2FA) ist aktiviert
+    enabled_success: Zwei-Faktor-Authentisierung (2FA) erfolgreich aktiviert
+    generate_recovery_codes: Wiederherstellungscodes erstellen
+    lost_recovery_codes: Wiederherstellungscodes ermöglichen es dir, wieder Zugang zu deinem Konto zu erlangen, falls du keinen Zugriff mehr auf die Zwei-Faktor-Authentisierung oder den Sicherheitsschlüssel hast. Solltest du diese Wiederherstellungscodes verloren haben, kannst du sie hier neu generieren. Deine alten, bereits erstellten Wiederherstellungscodes werden dadurch ungültig.
+    methods: Methoden der Zwei-Faktor-Authentisierung
+    otp: Authentisierungs-App
+    recovery_codes: Wiederherstellungscodes sichern
+    recovery_codes_regenerated: Wiederherstellungscodes erfolgreich neu erstellt
+    recovery_instructions_html: Falls du jemals den Zugang zu deinem Smartphone verlierst, kannst du einen der unten aufgeführten Wiederherstellungscodes verwenden, um wieder Zugang zu deinem Konto zu erhalten. <strong>Bewahre die Wiederherstellungscodes sicher auf</strong>. Du kannst sie zum Beispiel ausdrucken und zusammen mit anderen wichtigen Dokumenten aufbewahren.
+    webauthn: Sicherheitsschlüssel
+  user_mailer:
+    announcement_published:
+      description: 'Ankündigung der Administrator*innen von %{domain}:'
+      subject: Ankündigung
+      title: Ankündigung von %{domain}
+    appeal_approved:
+      action: Kontoeinstellungen
+      explanation: Der Einspruch gegen deinen Verstoß vom %{strike_date}, den du am %{appeal_date} eingereicht hast, wurde genehmigt. Dein Konto ist wieder in Ordnung.
+      subject: Dein Einspruch vom %{date} wurde angenommen
+      subtitle: Dein Konto ist wieder in Ordnung.
+      title: Einspruch angenommen
+    appeal_rejected:
+      explanation: Der Einspruch gegen deinen Verstoß vom %{strike_date}, den du am %{appeal_date} eingereicht hast, wurde abgelehnt.
+      subject: Dein Einspruch vom %{date} wurde abgelehnt
+      subtitle: Dein Einspruch wurde abgelehnt.
+      title: Einspruch abgelehnt
+    backup_ready:
+      explanation: Du hast eine vollständige Datensicherung deines Mastodon-Kontos angefordert.
+      extra: Sie ist jetzt zum Herunterladen bereit!
+      subject: Dein persönliches Archiv kann heruntergeladen werden
+      title: Archiv-Download
+    failed_2fa:
+      details: 'Details zum Anmeldeversuch:'
+      explanation: Jemand hat versucht, sich bei deinem Konto anzumelden, aber die Zwei-Faktor-Authentisierung schlug fehl.
+      further_actions_html: Solltest du das nicht gewesen sein, empfehlen wir dir, sofort %{action}, da dein Konto möglicherweise kompromittiert ist.
+      subject: Zwei-Faktor-Authentisierung fehlgeschlagen
+      title: Zwei-Faktor-Authentisierung fehlgeschlagen
+    suspicious_sign_in:
+      change_password: dein Passwort zu ändern
+      details: 'Hier sind die Details zu den Anmeldeversuchen:'
+      explanation: Wir haben eine Anmeldung zu deinem Konto von einer neuen IP-Adresse festgestellt.
+      further_actions_html: Wenn du das nicht warst, empfehlen wir dir schnellstmöglich, %{action} und die Zwei-Faktor-Authentisierung für dein Konto zu aktivieren, um es abzusichern.
+      subject: Es wurde auf dein Konto von einer neuen IP-Adresse zugegriffen
+      title: Eine neue Anmeldung
+    terms_of_service_changed:
+      agreement: Du stimmst den neuen Nutzungsbedingungen automatisch zu, wenn du %{domain} weiterhin verwendest. Falls du mit diesen nicht einverstanden bist, kannst du die Vereinbarung mit %{domain} jederzeit widerrufen, indem du dein Konto dort löschst.
+      changelog: 'Die Änderungen im Überblick:'
+      description: 'Du erhältst diese E-Mail, weil wir für %{domain} einige Änderungen an unseren Nutzungsbedingungen vorgenommen haben. Diese Änderungen gelten ab %{date}. Wir empfehlen, die vollständig aktualisierte Fassung hier zu lesen:'
+      description_html: Du erhältst diese E-Mail, weil wir für %{domain} einige Änderungen an unseren Nutzungsbedingungen vorgenommen haben. Diese Änderungen gelten ab <strong>%{date}</strong>. Wir empfehlen, die <a href="%{path}" target="_blank">vollständig aktualisierte Fassung hier zu lesen</a>.
+      sign_off: Das Team von %{domain}
+      subject: Aktualisierung unserer Nutzungsbedingungen
+      subtitle: Die Nutzungsbedingungen von %{domain} ändern sich
+      title: Wichtige Mitteilung
+    warning:
+      appeal: Einspruch erheben
+      appeal_description: Wenn du glaubst, dass es sich um einen Fehler handelt, kannst du einen Einspruch an die Administration von %{instance} senden.
+      categories:
+        spam: Spam
+        violation: Inhalt verstößt gegen die folgenden Serverregeln
+      explanation:
+        delete_statuses: Einige deiner Beiträge haben gegen eine oder mehrere Serverregeln verstoßen und wurden daher von den Moderator*innen von %{instance} entfernt.
+        disable: Du kannst dein Konto nicht mehr verwenden, aber dein Profil und deine anderen Daten bleiben erhalten. Du kannst eine Sicherung deiner Daten anfordern, die Kontoeinstellungen ändern oder dein Konto löschen.
+        mark_statuses_as_sensitive: Ein oder mehrere deiner Beiträge wurden von den Moderator*innen von %{instance} mit einer Inhaltswarnung versehen. Das bedeutet, dass die Medien in den Beiträgen erst angeklickt werden müssen, bevor sie angezeigt werden. Beim Verfassen der nächsten Beiträge kannst du auch selbst eine Inhaltswarnung für hochgeladene Medien festlegen.
+        sensitive: Von nun an werden alle deine hochgeladenen Mediendateien mit einer Inhaltswarnung versehen und hinter einer Warnung versteckt.
+        silence: Du kannst dein Konto weiterhin verwenden, aber nur Personen, die dir bereits folgen, sehen deine Beiträge auf diesem Server. Ebenso kannst du aus verschiedenen Suchfunktionen ausgeschlossen werden. Andere können dir jedoch weiterhin manuell folgen.
+        suspend: Du kannst dein Konto nicht mehr verwenden und dein Profil und andere Daten sind nicht mehr verfügbar. Du kannst dich immer noch anmelden, um eine Sicherung deiner Daten anzufordern, bis die Daten innerhalb von 30 Tagen vollständig gelöscht wurden. Allerdings werden wir einige Daten speichern, um zu verhindern, dass du die Sperrung umgehst.
+      reason: 'Begründung:'
+      statuses: 'Betroffene Beiträge:'
+      subject:
+        delete_statuses: Deine Beiträge von %{acct} sind entfernt worden
+        disable: Dein Konto %{acct} wurde eingefroren
+        mark_statuses_as_sensitive: Deine Beiträge von %{acct} wurden mit einer Inhaltswarnung versehen
+        none: Warnung für %{acct}
+        sensitive: Deine Beiträge von %{acct} werden künftig mit einer Inhaltswarnung versehen
+        silence: Dein Konto %{acct} wurde eingeschränkt
+        suspend: Dein Konto %{acct} wurde gesperrt
+      title:
+        delete_statuses: Beiträge entfernt
+        disable: Konto eingefroren
+        mark_statuses_as_sensitive: Mit einer Inhaltswarnung versehene Beiträge
+        none: Warnung
+        sensitive: Konto mit einer Inhaltswarnung versehen
+        silence: Konto stummgeschaltet
+        suspend: Konto gesperrt
+    welcome:
+      apps_android_action: Aus dem Google Play Store herunterladen
+      apps_ios_action: Im App Store herunterladen
+      apps_step: Lade unsere offiziellen Apps herunter.
+      apps_title: Mastodon-Apps
+      checklist_subtitle: 'Fangen wir an, diese neue soziale Dimension zu erkunden:'
+      checklist_title: Willkommensleitfaden
+      edit_profile_action: Personalisieren
+      edit_profile_step: Mit einem vollständigen Profil interagieren andere eher mit dir.
+      edit_profile_title: Personalisiere dein Profil
+      explanation: Hier sind ein paar Tipps, um loszulegen
+      feature_action: Mehr erfahren
+      feature_audience: Mastodon bietet dir eine einzigartige Möglichkeit, deine Reichweite ohne Mittelsperson zu verwalten. Auf deiner eigenen Infrastruktur bereitgestellt, ermöglicht Mastodon es dir, jedem anderen Mastodon-Server zu folgen und von jedem anderen Server aus gefolgt zu werden. Ebenso steht Mastodon unter deiner Kontrolle.
+      feature_audience_title: Baue deine Reichweite mit Vertrauen auf
+      feature_control: Du weißt am besten, was du auf deiner Startseite sehen möchtest. Keine Algorithmen oder Werbung, die deine Zeit verschwenden. Folge Nutzer*innen auf allen Mastodon-Servern von einem einzelnen Konto aus und empfange deren Beiträge in chronologischer Reihenfolge. Mache Mastodon zu deinem ganz persönlichen Fleckchen im Internet.
+      feature_control_title: Behalte die Kontrolle über deine eigene Timeline
+      feature_creativity: Mastodon unterstützt Audio-, Video- und Bildbeiträge, Beschreibungen, Umfragen, Inhaltswarnungen, animierte Avatare, benutzerdefinierte Emojis, das Zuschneiden von Vorschaubildern und vieles mehr, um dir zu helfen, dich online zu entfalten. Egal, ob du deine Kunst, deine Musik oder deinen Podcast veröffentlichst – Mastodon ist für dich da.
+      feature_creativity_title: Einzigartige Kreativität
+      feature_moderation: Mastodon legt die Entscheidungskraft zurück in deine Hände. Jeder Server erstellt eigene Regeln und Vorschriften, die nur lokal, pro einzelnem Server durchgesetzt werden – und nicht von oben herab, wie es bei den kommerziellen sozialen Medien der Fall ist. Dadurch ist Mastodon viel anpassungsfähiger für verschiedene Gruppen von Menschen. Registriere dich bei einem Server, dessen Regeln du magst, oder hoste deinen eigenen Server.
+      feature_moderation_title: Moderation so, wie sie sein sollte
+      follow_action: Folgen
+      follow_step: Interessanten Profilen zu folgen ist das, was Mastodon ausmacht.
+      follow_title: Personalisiere deine Startseite
+      follows_subtitle: Folge bekannten Profilen
+      follows_title: Empfohlene Profile
+      follows_view_more: Weitere Profile zum Folgen entdecken
+      hashtags_recent_count:
+        one: "%{people} Profil in den vergangenen 2 Tagen"
+        other: "%{people} Profile in den vergangenen 2 Tagen"
+      hashtags_subtitle: Entdecke, was in den vergangenen 2 Tagen angesagt war
+      hashtags_title: Angesagte Hashtags
+      hashtags_view_more: Weitere angesagte Hashtags entdecken
+      post_action: Verfassen
+      post_step: Begrüße die Welt mit Text, Fotos, Videos oder Umfragen.
+      post_title: Erstelle deinen ersten Beitrag
+      share_step: Lass deine Freund*innen wissen, wie sie dich auf Mastodon finden können.
+      share_title: Teile dein Mastodon-Profil
+      sign_in_action: Anmelden
+      subject: Willkommen bei Mastodon!
+      title: Willkommen an Bord, %{name}!
+  users:
+    follow_limit_reached: Du kannst nicht mehr als %{limit} Profilen folgen
+    go_to_sso_account_settings: Kontoeinstellungen des Identitätsanbieters aufrufen
+    invalid_otp_token: Ungültiger Code der Zwei-Faktor-Authentisierung
+    otp_lost_help_html: Wenn du beides nicht mehr weißt, melde dich bitte bei uns unter der E-Mail-Adresse %{email}
+    rate_limited: Zu viele Authentisierungsversuche. Bitte versuche es später noch einmal.
+    seamless_external_login: Du bist über einen externen Dienst angemeldet, daher sind Passwort- und E-Mail-Einstellungen nicht verfügbar.
+    signed_in_as: 'Angemeldet als:'
+  verification:
+    extra_instructions_html: <strong>Hinweis:</strong> Der Link auf deiner Website kann unsichtbar sein. Der wichtige Teil ist <code>rel="me"</code>. Du kannst auch den Tag <code>link</code> im <code>head</code> (statt <code>a</code> im <code>body</code>) verwenden, jedoch muss die Internetseite ohne JavaScript abrufbar sein.
+    here_is_how: So funktioniert’s
+    hint_html: "<strong>Alle können ihre Identität auf Mastodon verifizieren.</strong> Basierend auf offenen Standards – jetzt und für immer kostenlos. Alles, was du brauchst, ist eine eigene Website. Wenn du von deinem Profil auf diese Website verlinkst, überprüfen wir, ob die Website zu deinem Profil zurückverlinkt, und zeigen einen visuellen Hinweis an."
+    instructions_html: Kopiere den unten stehenden Code und füge ihn in den HTML-Code deiner Website ein. Trage anschließend die Adresse deiner Website in ein Zusatzfeld auf deinem Profil ein und speichere die Änderungen. Die Zusatzfelder befinden sich im Reiter „Profil bearbeiten“.
+    verification: Verifizierung
+    verified_links: Deine verifizierten Domains
+    website_verification: Verifizierung einer Website
+  webauthn_credentials:
+    add: Sicherheitsschlüssel hinzufügen
+    create:
+      error: Beim Hinzufügen des Sicherheitsschlüssels ist ein Fehler aufgetreten. Bitte versuche es erneut.
+      success: Dein Sicherheitsschlüssel wurde erfolgreich hinzugefügt.
+    delete: Entfernen
+    delete_confirmation: Möchtest du diesen Sicherheitsschlüssel wirklich entfernen?
+    description_html: Wenn du die <strong>Authentisierung mit Sicherheitsschlüssel</strong> aktivierst, musst du dich mit einem deiner Sicherheitsschlüssel anmelden.
+    destroy:
+      error: Beim Entfernen des Sicherheitsschlüssels ist ein Fehler aufgetreten. Bitte versuche es erneut.
+      success: Dein Sicherheitsschlüssel wurde erfolgreich entfernt.
+    invalid_credential: Ungültiger Sicherheitsschlüssel
+    nickname_hint: Gib den Spitznamen deines neuen Sicherheitsschlüssels ein
+    not_enabled: Du hast WebAuthn noch nicht aktiviert
+    not_supported: Dieser Browser unterstützt keine Sicherheitsschlüssel
+    otp_required: Um Sicherheitsschlüssel zu verwenden, aktiviere zunächst die Zwei-Faktor-Authentisierung.
+    registered_on: Registriert am %{date}

--- a/config/locales/hsb.yml
+++ b/config/locales/hsb.yml
@@ -1,2 +1,2152 @@
 ---
-hsb: {}
+hsb:
+  about:
+    about_mastodon_html: 'Das soziale Netzwerk der Zukunft: Keine Werbung, keine Überwachung durch Unternehmen – dafür dezentral und mit Anstand! Behalte mit Mastodon die Kontrolle über deine Daten!'
+    contact_missing: Nicht festgelegt
+    contact_unavailable: Nicht verfügbar
+    hosted_on: Mastodon, gehostet auf %{domain}
+    title: Über
+  accounts:
+    followers:
+      one: Follower
+      other: Follower
+    following: Folge ich
+    instance_actor_flash: Dieses Konto ist ein virtueller Akteur, der den Server selbst repräsentiert, und kein persönliches Profil. Es wird für Föderationszwecke verwendet und sollte daher nicht gesperrt werden.
+    last_active: zuletzt aktiv
+    link_verified_on: Das Profil mit dieser E-Mail-Adresse wurde bereits am %{date} bestätigt
+    nothing_here: Keine Treffer mit dieser Auswahl
+    pin_errors:
+      following: Du musst dieser Person folgen, um sie empfehlen zu können
+    posts:
+      one: Beitrag
+      other: Beiträge
+    posts_tab_heading: Beiträge
+    self_follow_error: Es ist nicht erlaubt, deinem eigenen Konto zu folgen
+  admin:
+    account_actions:
+      action: Aktion ausführen
+      already_silenced: Dieses Konto wurde bereits eingeschränkt.
+      already_suspended: Dieses Konto wurde bereits gesperrt.
+      title: "@%{acct} moderieren"
+    account_moderation_notes:
+      create: Notiz abspeichern
+      created_msg: Moderationshinweis erfolgreich abgespeichert!
+      destroyed_msg: Moderationsnotiz erfolgreich entfernt!
+    accounts:
+      add_email_domain_block: E-Mail-Domain sperren
+      approve: Genehmigen
+      approved_msg: Antrag zur Registrierung von %{username} erfolgreich genehmigt
+      are_you_sure: Bist du dir sicher?
+      avatar: Profilbild
+      by_domain: Domain
+      change_email:
+        changed_msg: E-Mail-Adresse erfolgreich geändert!
+        current_email: Aktuelle E-Mail-Adresse
+        label: E-Mail-Adresse ändern
+        new_email: Neue E-Mail-Adresse
+        submit: E-Mail-Adresse ändern
+        title: E-Mail-Adresse für %{username} ändern
+      change_role:
+        changed_msg: Rolle erfolgreich geändert!
+        edit_roles: Rollen verwalten
+        label: Rolle ändern
+        no_role: Keine Rolle
+        title: Rolle für %{username} ändern
+      confirm: Bestätigen
+      confirmed: Bestätigt
+      confirming: Bestätigung
+      custom: Angepasst
+      delete: Daten löschen
+      deleted: Gelöscht
+      demote: Zurückstufen
+      destroyed_msg: Daten von %{username} wurden zum Löschen in die Warteschlange eingereiht
+      disable: Einfrieren
+      disable_sign_in_token_auth: E-Mail-Token-Authentisierung deaktivieren
+      disable_two_factor_authentication: Zwei-Faktor-Authentisierung deaktivieren
+      disabled: Eingefroren
+      display_name: Anzeigename
+      domain: Domain
+      edit: Bearbeiten
+      email: E-Mail-Adresse
+      email_status: Status der E-Mail-Adresse
+      enable: Freischalten
+      enable_sign_in_token_auth: E-Mail-Token-Authentisierung aktivieren
+      enabled: Freigegeben
+      enabled_msg: Konto von %{username} erfolgreich freigegeben
+      followers: Follower
+      follows: Folge ich
+      header: Titelbild
+      inbox_url: Posteingangsadresse
+      invite_request_text: Begründung für das Beitreten
+      invited_by: Eingeladen von
+      ip: IP-Adresse
+      joined: Mitglied seit
+      location:
+        all: Alle
+        local: Lokal
+        remote: Extern
+        title: Herkunft
+      login_status: Status
+      media_attachments: Medienanhänge
+      memorialize: In Gedenkseite umwandeln
+      memorialized: Gedenkseite
+      memorialized_msg: "%{username} wurde erfolgreich in ein Gedenkseiten-Konto umgewandelt"
+      moderation:
+        active: Aktiv
+        all: Alle
+        disabled: Deaktiviert
+        pending: In Warteschlange
+        silenced: Stummgeschaltet
+        suspended: Gesperrt
+        title: Moderation
+      moderation_notes: Moderationsnotizen
+      most_recent_activity: Letzte Aktivität
+      most_recent_ip: Letzte IP-Adresse
+      no_account_selected: Keine Konten wurden geändert, da keine ausgewählt wurden
+      no_limits_imposed: Keine Beschränkungen
+      no_role_assigned: Keine Rolle zugewiesen
+      not_subscribed: Nicht abonniert
+      pending: Überprüfung ausstehend
+      perform_full_suspension: Sperren
+      previous_strikes: Vorherige Maßnahmen
+      previous_strikes_description_html:
+        one: Gegen dieses Konto wurde <strong>eine</strong> Maßnahme verhängt.
+        other: Gegen dieses Konto wurden <strong>%{count}</strong> Maßnahmen verhängt.
+      promote: Berechtigungen erweitern
+      protocol: Protokoll
+      public: Öffentlich
+      push_subscription_expires: PuSH-Abonnement läuft aus
+      redownload: Profil neu laden
+      redownloaded_msg: Das Profil %{username} wurde vom externen Server erfolgreich aktualisiert
+      reject: Ablehnen
+      rejected_msg: Antrag zur Registrierung von %{username} erfolgreich abgelehnt
+      remote_suspension_irreversible: Die Daten dieses Kontos wurden unwiderruflich gelöscht.
+      remote_suspension_reversible_hint_html: Das Konto wurde auf dem externen Server gesperrt – und sämtliche Daten werden am %{date} entfernt. Bis dahin kann dieser Server das Konto ohne negative Auswirkungen wiederherstellen. Wenn du schon jetzt alle Daten des Kontos unwiderruflich löschen möchtest, kannst du dies nachfolgend tun.
+      remove_avatar: Profilbild entfernen
+      remove_header: Titelbild entfernen
+      removed_avatar_msg: Profilbild von %{username} erfolgreich entfernt
+      removed_header_msg: Titelbild von %{username} wurde erfolgreich entfernt
+      resend_confirmation:
+        already_confirmed: Dieses Profil wurde bereits bestätigt
+        send: Bestätigungslink erneut zusenden
+        success: Bestätigungslink erfolgreich gesendet!
+      reset: Zurücksetzen
+      reset_password: Passwort zurücksetzen
+      resubscribe: Erneut abonnieren
+      role: Rolle
+      search: Suchen
+      search_same_email_domain: Andere Konten mit der gleichen E-Mail-Domain
+      search_same_ip: Andere Konten mit derselben IP-Adresse
+      security: Sicherheit
+      security_measures:
+        only_password: Nur Passwort
+        password_and_2fa: Passwort und 2FA
+      sensitive: Inhaltswarnung
+      sensitized: Mit Inhaltswarnung versehen
+      shared_inbox_url: Geteilte Posteingangsadresse
+      show:
+        created_reports: Erstellte Meldungen
+        targeted_reports: Von Anderen gemeldet
+      silence: Stummschalten
+      silenced: Stummgeschaltet
+      statuses: Beiträge
+      strikes: Vorherige Maßnahmen
+      subscribe: Abonnieren
+      suspend: Sperren
+      suspended: Gesperrt
+      suspension_irreversible: Die Daten dieses Kontos wurden unwiderruflich gelöscht. Du kannst das Konto entsperren, um es wieder zu verwenden, aber es wird keine Daten wiederherstellen, die es davor hatte.
+      suspension_reversible_hint_html: Das Konto wurde gesperrt und die Daten werden am %{date} vollständig gelöscht. Bis dahin kann das Konto ohne irgendwelche negativen Auswirkungen wiederhergestellt werden. Wenn du alle Daten des Kontos sofort entfernen möchtest, kannst du das nachfolgend tun.
+      title: Konten
+      unblock_email: E-Mail-Adresse entsperren
+      unblocked_email_msg: E-Mail-Adresse von %{username} erfolgreich entsperrt
+      unconfirmed_email: Unbestätigte E-Mail-Adresse
+      undo_sensitized: Inhaltswarnung aufheben
+      undo_silenced: Stummschaltung aufheben
+      undo_suspension: Sperre aufheben
+      unsilenced_msg: Konto von %{username} erfolgreich freigegeben
+      unsubscribe: Abbestellen
+      unsuspended_msg: Kontosperre von %{username} erfolgreich aufgehoben
+      username: Profilname
+      view_domain: Übersicht für Domain anzeigen
+      warn: Verwarnen
+      web: Web
+      whitelisted: Für Föderation zugelassen
+    action_logs:
+      action_types:
+        approve_appeal: Einspruch zulassen
+        approve_user: Benutzer*in genehmigen
+        assigned_to_self_report: Meldung zuweisen
+        change_email_user: E-Mail des Profils ändern
+        change_role_user: Rolle des Profils ändern
+        confirm_user: Benutzer*in bestätigen
+        create_account_warning: Warnung erstellen
+        create_announcement: Ankündigung erstellen
+        create_canonical_email_block: E-Mail-Sperre erstellen
+        create_custom_emoji: Eigene Emojis erstellen
+        create_domain_allow: Domain erlauben
+        create_domain_block: Domain sperren
+        create_email_domain_block: E-Mail-Domain-Sperre erstellen
+        create_ip_block: IP-Regel erstellen
+        create_relay: Relais erstellen
+        create_unavailable_domain: Nicht verfügbare Domain erstellen
+        create_user_role: Rolle erstellen
+        create_username_block: Regel für Profilnamen erstellen
+        demote_user: Benutzer*in herabstufen
+        destroy_announcement: Ankündigung löschen
+        destroy_canonical_email_block: E-Mail-Sperre entfernen
+        destroy_custom_emoji: Eigenes Emojis löschen
+        destroy_domain_allow: Erlaube das Löschen von Domains
+        destroy_domain_block: Domain-Sperre entfernen
+        destroy_email_domain_block: E-Mail-Domain-Sperre entfernen
+        destroy_instance: Domain-Daten entfernen
+        destroy_ip_block: IP-Regel löschen
+        destroy_relay: Relais löschen
+        destroy_status: Beitrag entfernen
+        destroy_unavailable_domain: Nicht-verfügbare Domain entfernen
+        destroy_user_role: Rolle entfernen
+        destroy_username_block: Regel für Profilnamen löschen
+        disable_2fa_user: 2FA deaktivieren
+        disable_custom_emoji: Eigenes Emoji deaktivieren
+        disable_relay: Relais deaktivieren
+        disable_sign_in_token_auth_user: E-Mail-Token-Authentisierung für dieses Konto deaktivieren
+        disable_user: Benutzer*in deaktivieren
+        enable_custom_emoji: Eigenes Emoji aktivieren
+        enable_relay: Relais aktivieren
+        enable_sign_in_token_auth_user: E-Mail-Token-Authentisierung für dieses Konto aktivieren
+        enable_user: Benutzer*in aktivieren
+        memorialize_account: Gedenkkonto
+        promote_user: Benutzer*in hochstufen
+        publish_terms_of_service: Nutzungsbedingungen veröffentlichen
+        reject_appeal: Einspruch ablehnen
+        reject_user: Benutzer*in ablehnen
+        remove_avatar_user: Profilbild entfernen
+        reopen_report: Meldung wieder eröffnen
+        resend_user: Bestätigungs-E-Mail erneut senden
+        reset_password_user: Passwort zurücksetzen
+        resolve_report: Meldung klären
+        sensitive_account: Konto mit erzwungener Inhaltswarnung
+        silence_account: Konto stummschalten
+        suspend_account: Konto sperren
+        unassigned_report: Meldung widerrufen
+        unblock_email_account: E-Mail-Adresse entsperren
+        unsensitive_account: Konto mit erzwungener Inhaltswarnung rückgängig machen
+        unsilence_account: Konto nicht mehr stummschalten
+        unsuspend_account: Konto entsperren
+        update_announcement: Ankündigung aktualisieren
+        update_custom_emoji: Eigenes Emoji aktualisieren
+        update_domain_block: Domain-Sperre aktualisieren
+        update_ip_block: IP-Regel aktualisieren
+        update_report: Meldung aktualisieren
+        update_status: Beitrag aktualisieren
+        update_user_role: Rolle bearbeiten
+        update_username_block: Regel für Profilnamen aktualisieren
+      actions:
+        approve_appeal_html: "%{name} hat den Einspruch gegen eine Moderationsentscheidung von %{target} genehmigt"
+        approve_user_html: "%{name} genehmigte die Registrierung von %{target}"
+        assigned_to_self_report_html: "%{name} wies sich die Meldung %{target} selbst zu"
+        change_email_user_html: "%{name} änderte die E-Mail-Adresse von %{target}"
+        change_role_user_html: "%{name} hat die Rolle von %{target} geändert"
+        confirm_user_html: "%{name} bestätigte die E-Mail-Adresse von %{target}"
+        create_account_warning_html: "%{name} sendete eine Warnung an %{target}"
+        create_announcement_html: "%{name} erstellte die neue Ankündigung: %{target}"
+        create_canonical_email_block_html: "%{name} sperrte die E-Mail mit dem Hash %{target}"
+        create_custom_emoji_html: "%{name} lud das neue Emoji %{target} hoch"
+        create_domain_allow_html: "%{name} erlaubte die Föderation mit der Domain %{target}"
+        create_domain_block_html: "%{name} sperrte die Domain %{target}"
+        create_email_domain_block_html: "%{name} sperrte die E-Mail-Domain %{target}"
+        create_ip_block_html: "%{name} erstellte eine IP-Regel für %{target}"
+        create_relay_html: "%{name} erstellte ein Relay %{target}"
+        create_unavailable_domain_html: "%{name} beendete die Zustellung an die Domain %{target}"
+        create_user_role_html: "%{name} erstellte die Rolle %{target}"
+        create_username_block_html: "%{name} erstellte eine Regel für Profilnamen mit %{target}"
+        demote_user_html: "%{name} stufte %{target} herunter"
+        destroy_announcement_html: "%{name} löschte die Ankündigung %{target}"
+        destroy_canonical_email_block_html: "%{name} entsperrte die E-Mail mit dem Hash %{target}"
+        destroy_custom_emoji_html: "%{name} löschte das Emoji %{target}"
+        destroy_domain_allow_html: "%{name} verwehrte die Föderation mit der Domain %{target}"
+        destroy_domain_block_html: "%{name} entsperrte die Domain %{target}"
+        destroy_email_domain_block_html: "%{name} entsperrte die E-Mail-Domain %{target}"
+        destroy_instance_html: "%{name} entfernte die Daten der Domain %{target} von diesem Server"
+        destroy_ip_block_html: "%{name} entfernte eine IP-Regel für %{target}"
+        destroy_relay_html: "%{name} löschte das Relais %{target}"
+        destroy_status_html: "%{name} entfernte einen Beitrag von %{target}"
+        destroy_unavailable_domain_html: "%{name} nahm die Zustellung an die Domain %{target} wieder auf"
+        destroy_user_role_html: "%{name} löschte die Rolle %{target}"
+        destroy_username_block_html: "%{name} entfernte eine Regel für Profilnamen mit %{target}"
+        disable_2fa_user_html: "%{name} deaktivierte die Zwei-Faktor-Authentisierung für %{target}"
+        disable_custom_emoji_html: "%{name} deaktivierte das Emoji %{target}"
+        disable_relay_html: "%{name} deaktivierte das Relais %{target}"
+        disable_sign_in_token_auth_user_html: "%{name} deaktivierte die E-Mail-Token-Authentisierung für %{target}"
+        disable_user_html: "%{name} deaktivierte den Zugang für %{target}"
+        enable_custom_emoji_html: "%{name} aktivierte das Emoji %{target}"
+        enable_relay_html: "%{name} aktivierte das Relais %{target}"
+        enable_sign_in_token_auth_user_html: "%{name} aktivierte die E-Mail-Token-Authentisierung für %{target}"
+        enable_user_html: "%{name} aktivierte den Zugang für %{target}"
+        memorialize_account_html: "%{name} wandelte das Konto von %{target} in eine Gedenkseite um"
+        promote_user_html: "%{name} beförderte %{target}"
+        publish_terms_of_service_html: "%{name} aktualisierte die Nutzungsbedingungen"
+        reject_appeal_html: "%{name} hat den Einspruch gegen eine Moderationsentscheidung von %{target} abgelehnt"
+        reject_user_html: "%{name} hat die Registrierung von %{target} abgelehnt"
+        remove_avatar_user_html: "%{name} entfernte das Profilbild von %{target}"
+        reopen_report_html: "%{name} öffnete die Meldung %{target} wieder"
+        resend_user_html: "%{name} versendete erneut die E-Mail-Bestätigung für %{target}"
+        reset_password_user_html: "%{name} setzte das Passwort von %{target} zurück"
+        resolve_report_html: "%{name} klärte die Meldung %{target}"
+        sensitive_account_html: "%{name} versah die Medien von %{target} mit einer Inhaltswarnung"
+        silence_account_html: "%{name} schaltete das Konto von %{target} stumm"
+        suspend_account_html: "%{name} sperrte das Konto von %{target}"
+        unassigned_report_html: "%{name} entfernte die Zuweisung der Meldung %{target}"
+        unblock_email_account_html: "%{name} hat die E-Mail-Adresse von %{target} entsperrt"
+        unsensitive_account_html: "%{name} hat die Inhaltswarnung für Medien von %{target} aufgehoben"
+        unsilence_account_html: "%{name} hob die Stummschaltung von %{target} auf"
+        unsuspend_account_html: "%{name} entsperrte das Konto von %{target}"
+        update_announcement_html: "%{name} überarbeitete die Ankündigung %{target}"
+        update_custom_emoji_html: "%{name} bearbeitete das Emoji %{target}"
+        update_domain_block_html: "%{name} aktualisierte die Domain-Sperre für %{target}"
+        update_ip_block_html: "%{name} änderte die Regel für die IP-Adresse %{target}"
+        update_report_html: "%{name} überarbeitete die Meldung %{target}"
+        update_status_html: "%{name} überarbeitete einen Beitrag von %{target}"
+        update_user_role_html: "%{name} änderte die Rolle von %{target}"
+        update_username_block_html: "%{name} aktualisierte eine Regel für Profilnamen mit %{target}"
+      deleted_account: gelöschtes Konto
+      empty: Protokolle nicht gefunden.
+      filter_by_action: Nach Aktion filtern
+      filter_by_user: Nach Benutzer*in filtern
+      title: Audit-Log
+      unavailable_instance: "(Server nicht verfügbar)"
+    announcements:
+      back: Zurück zu den Ankündigungen
+      destroyed_msg: Ankündigung erfolgreich gelöscht!
+      edit:
+        title: Ankündigung bearbeiten
+      empty: Keine Ankündigungen vorhanden.
+      live: Aktuell gültig
+      new:
+        create: Ankündigung erstellen
+        title: Neue Ankündigung
+      preview:
+        disclaimer: Da sich Profile nicht davon abmelden können, sollten Benachrichtigungen per E-Mail auf wichtige Ankündigungen wie z. B. zu Datenpannen oder Serverabschaltung beschränkt sein.
+        explanation_html: 'Die E-Mail wird an <strong>%{display_count} Nutzer*innen</strong> gesendet. Folgendes wird in der E-Mail enthalten sein:'
+        title: Vorschau der Ankündigung
+      publish: Veröffentlichen
+      published_msg: Ankündigung erfolgreich veröffentlicht!
+      scheduled_for: Geplant für %{time}
+      scheduled_msg: Ankündigung ist zur Veröffentlichung vorgemerkt!
+      title: Ankündigungen
+      unpublish: Veröffentlichung rückgängig machen
+      unpublished_msg: Ankündigung ist jetzt nicht mehr sichtbar!
+      updated_msg: Ankündigung erfolgreich aktualisiert!
+    critical_update_pending: Kritisches Update ausstehend
+    custom_emojis:
+      assign_category: Kategorie zuweisen
+      by_domain: Domain
+      copied_msg: Lokale Kopie des Emojis erfolgreich erstellt
+      copy: Kopieren
+      copy_failed_msg: Es konnte keine lokale Kopie dieses Emojis auf diesem Server erstellt werden
+      create_new_category: Neue Kategorie erstellen
+      created_msg: Emoji erfolgreich erstellt!
+      delete: Löschen
+      destroyed_msg: Emoji erfolgreich gelöscht!
+      disable: Deaktivieren
+      disabled: Deaktiviert
+      disabled_msg: Dieses Emoji wurde erfolgreich deaktiviert
+      emoji: Emoji
+      enable: Aktivieren
+      enabled: Aktiviert
+      enabled_msg: Dieses Emoji wurde erfolgreich aktiviert
+      image_hint: PNG oder GIF bis %{size}
+      list: Anzeigen
+      listed: Sichtbar
+      new:
+        title: Eigenes Emoji hinzufügen
+      no_emoji_selected: Keine Emojis wurden bearbeitet, da keine ausgewählt wurden
+      not_permitted: Du bist für die Durchführung dieses Vorgangs nicht berechtigt
+      overwrite: Überschreiben
+      shortcode: Shortcode
+      shortcode_hint: Mindestens 2 Zeichen, nur Buchstaben, Ziffern und Unterstriche
+      title: Eigene Emojis
+      uncategorized: Unkategorisiert
+      unlist: Nicht anzeigen
+      unlisted: Öffentlich (still)
+      update_failed_msg: Konnte dieses Emoji nicht bearbeiten
+      updated_msg: Emoji erfolgreich bearbeitet!
+      upload: Hochladen
+    dashboard:
+      active_users: aktive Profile
+      interactions: Interaktionen
+      media_storage: Medien
+      new_users: neue Profile
+      opened_reports: eingereichte Meldungen
+      pending_appeals_html:
+        one: "<strong>%{count}</strong> ausstehender Einspruch"
+        other: "<strong>%{count}</strong> ausstehende Einsprüche"
+      pending_reports_html:
+        one: "<strong>%{count}</strong> offene Meldung"
+        other: "<strong>%{count}</strong> offene Meldungen"
+      pending_tags_html:
+        one: "<strong>%{count}</strong> ungeprüfter Hashtag"
+        other: "<strong>%{count}</strong> ungeprüfte Hashtags"
+      pending_users_html:
+        one: "<strong>%{count}</strong> unerledigte*r Benutzer*in"
+        other: "<strong>%{count}</strong> unerledigte Benutzer*innen"
+      resolved_reports: geklärte Meldungen
+      software: Programme
+      sources: Registrierungsort
+      space: Speicherplatz
+      title: Dashboard
+      top_languages: Häufigste Sprachen
+      top_servers: Aktivste Server
+      website: Website
+    disputes:
+      appeals:
+        empty: Keine Einsprüche gefunden.
+        title: Einsprüche
+    domain_allows:
+      add_new: Föderation mit Domain erlauben
+      created_msg: Domain wurde erfolgreich für die Föderation zugelassen
+      destroyed_msg: Domain wurde von der Föderation ausgeschlossen
+      export: Exportieren
+      import: Importieren
+      undo: Von der Föderation ausschließen
+    domain_blocks:
+      add_new: Neue Domain einschränken
+      confirm_suspension:
+        cancel: Abbrechen
+        confirm: Sperren
+        permanent_action: Das Aufheben der Sperre wird keine Daten oder Beziehungen wiederherstellen.
+        preamble_html: Du bist dabei, <strong>%{domain}</strong> und alle Subdomains zu sperren.
+        remove_all_data: Alle Inhalte, Medien und Profildaten werden für die Konten dieser Domain von deinem Server entfernt.
+        stop_communication: Dein Server wird nicht länger mit diesen Servern kommunizieren.
+        title: Sperre für Domain %{domain} bestätigen
+        undo_relationships: Jede Follower-Beziehung, die zwischen deinem und deren Server besteht, wird aufgelöst.
+      created_msg: Die Domain ist jetzt gesperrt bzw. eingeschränkt
+      destroyed_msg: Die Einschränkungen zu dieser Domain wurde entfernt
+      domain: Domain
+      edit: Einschränkungen bearbeiten
+      existing_domain_block: Du hast %{name} bereits stärker eingeschränkt.
+      existing_domain_block_html: Du hast bereits strengere Beschränkungen für die Domain %{name} verhängt. Du musst diese erst <a href="%{unblock_url}">aufheben</a>.
+      export: Exportieren
+      import: Importieren
+      new:
+        create: Server einschränken
+        hint: Die Einschränkung einer Domain wird nicht verhindern, dass Konteneinträge in der Datenbank erstellt werden. Es werden aber alle Moderationsmethoden rückwirkend und automatisch auf diese Konten angewendet.
+        severity:
+          desc_html: "<strong>Stummschalten</strong> wird Beiträge von Konten unter dieser Domain für alle unsichtbar machen, die den Konten nicht folgen. <strong>Sperren</strong> wird alle Inhalte, Medien und Profildaten für die Konten dieser Domain von deinem Server entfernen. Verwende <strong>Kein</strong>, wenn du nur Mediendateien ablehnen möchtest."
+          noop: Kein
+          silence: Stummschaltung
+          suspend: Sperren
+        title: Neue Domain einschränken
+      no_domain_block_selected: Keine Domains gesperrt, weil keine ausgewählt wurde(n)
+      not_permitted: Du bist nicht berechtigt, diese Aktion durchzuführen
+      obfuscate: Domain-Name verschleiern
+      obfuscate_hint: Den Domain-Namen öffentlich nur teilweise bekannt geben, sofern die Liste der Domain-Beschränkungen aktiviert ist
+      private_comment: Nicht-öffentliche Notiz
+      private_comment_hint: Kommentar zu dieser Domain-Beschränkung für die interne Nutzung durch die Moderator*innen.
+      public_comment: Öffentliche Begründung
+      public_comment_hint: Öffentlicher Hinweis zu dieser Domain-Beschränkung, sofern das Veröffentlichen von Sperrlisten grundsätzlich aktiviert ist.
+      reject_media: Mediendateien ablehnen
+      reject_media_hint: Entfernt lokal gespeicherte Mediendateien und verhindert deren künftiges Herunterladen. Für Sperren irrelevant
+      reject_reports: Meldungen ablehnen
+      reject_reports_hint: Alle Meldungen von dieser Domain ignorieren. Irrelevant für Sperrungen.
+      undo: Einschränkungen aufheben
+      view: Domain-Sperre ansehen
+    email_domain_blocks:
+      add_new: Neue hinzufügen
+      allow_registrations_with_approval: Registrierungen mit Genehmigung zulassen
+      attempts_over_week:
+        one: "%{count} Registrierungsversuch in der vergangenen Woche"
+        other: "%{count} Registrierungsversuche in der vergangenen Woche"
+      created_msg: E-Mail-Domain erfolgreich gesperrt
+      delete: Entfernen
+      dns:
+        types:
+          mx: MX-RR-Eintrag
+      domain: Domain
+      new:
+        create: E-Mail-Domain hinzufügen
+        resolve: Domain auflösen
+        title: Neue E-Mail-Domain sperren
+      no_email_domain_block_selected: Es wurden keine E-Mail-Domain-Sperren geändert, da keine ausgewählt wurden
+      not_permitted: Nicht gestattet
+      resolved_dns_records_hint_html: Die Domain wird zu den folgenden MX-Domains aufgelöst, die für die Annahme von E-Mails zuständig sind. Das Sperren einer MX-Domain sperrt Anmeldungen aller E-Mail-Adressen, die dieselbe MX-Domain verwenden, auch wenn die sichtbare Domain anders lautet. <strong>Achte daher darauf, keine großen E-Mail-Anbieter versehentlich zu sperren.</strong>
+      resolved_through_html: Durch %{domain} aufgelöst
+      title: Gesperrte E-Mail-Domains
+    export_domain_allows:
+      new:
+        title: Erlaubte Domains importieren
+      no_file: Keine Datei ausgewählt
+    export_domain_blocks:
+      import:
+        description_html: Du bist dabei, eine Liste von Domains zu importieren, die auf diesem Server gesperrt oder anderweitig eingeschränkt werden. Bitte überprüfe diese Liste sehr sorgfältig, insbesondere dann, wenn du sie nicht selbst erstellt hast.
+        existing_relationships_warning: Vorhandene Follower-Beziehungen
+        private_comment_description_html: 'Damit du später nachvollziehen kannst, woher die importierten Sperren stammen, werden sie mit diesem privaten Kommentar erstellt: <q>%{comment}</q>'
+        private_comment_template: Importiert von %{source} am %{date}
+        title: Domains importieren
+      invalid_domain_block: 'Ein oder mehrere Domainsperren wurden wegen folgenden Fehler(n) übersprungen: %{error}'
+      new:
+        title: Domains importieren
+      no_file: Keine Datei ausgewählt
+    fasp:
+      debug:
+        callbacks:
+          created_at: Erstellt am
+          delete: Entfernen
+          ip: IP-Adresse
+          request_body: Body anfragen
+          title: Callback testen
+      providers:
+        active: Aktiv
+        base_url: Basis-URL
+        callback: Callback
+        delete: Entfernen
+        edit: Anbieter bearbeiten
+        finish_registration: Registrierung abschließen
+        name: Name
+        providers: Anbieter
+        public_key_fingerprint: Fingerabdruck des öffentlichen Schlüssels
+        registration_requested: Registrierung angefordert
+        registrations:
+          confirm: Bestätigen
+          description: Sie haben eine Registrierung von einer FASP erhalten. Lehnen Sie ab, wenn Sie dies nicht initiiert haben. Wenn Sie dies initiiert haben, vergleichen Sie Namen und Fingerabdruck vor der Bestätigung der Registrierung.
+          reject: Ablehnen
+          title: FASP-Registrierung bestätigen
+        save: Speichern
+        select_capabilities: Leistungsfähigkeit auswählen
+        sign_in: Anmelden
+        status: Status
+        title: Fediverse Auxiliary Service Providers
+      title: FASP
+    follow_recommendations:
+      description_html: "<strong>Follower-Empfehlungen helfen neuen Nutzer*innen, interessante Inhalte schnell zu finden</strong>. Wenn ein*e Nutzer*in noch nicht genug mit anderen interagiert hat, um personalisierte Follower-Empfehlungen zu erhalten, werden stattdessen diese Profile vorgeschlagen. Sie werden täglich, basierend auf einer Mischung aus am meisten interagierenden Konten und jenen mit den meisten Followern für eine bestimmte Sprache neu berechnet."
+      language: Für Sprache
+      status: Status
+      suppress: Folgeempfehlung unterbinden
+      suppressed: Unterdrückt
+      title: Folgeempfehlungen
+      unsuppress: Folgeempfehlung nicht mehr unterbinden
+    instances:
+      audit_log:
+        title: Neueste Audit-Logs
+        view_all: Alle Audit-Logs anzeigen
+      availability:
+        description_html:
+          one: Wenn die Zustellung an die Domain <strong>%{count} Tag</strong> lang erfolglos bleibt, werden keine weiteren Zustellversuche unternommen, bis eine Zustellung <em>von</em> der Domain empfangen wird.
+          other: Wenn die Zustellung an die Domain an <strong>%{count} unterschiedlichen Tagen</strong> erfolglos bleibt, werden keine weiteren Zustellversuche unternommen, bis eine Zustellung <em>von</em> der Domain empfangen wird.
+        failure_threshold_reached: Grenzwert von Fehlschlägen am %{date} überschritten.
+        failures_recorded:
+          one: Fehlgeschlagener Versuch an %{count} Tag.
+          other: Fehlgeschlagene Versuche an %{count} unterschiedlichen Tagen.
+        no_failures_recorded: Keine Fehler bei der Aufzeichnung.
+        title: Verfügbarkeit
+        warning: Der letzte Versuch, sich mit diesem Server zu verbinden, war nicht erfolgreich
+      back_to_all: Alle
+      back_to_limited: Stummgeschaltet
+      back_to_warning: Warnung
+      by_domain: Domain
+      confirm_purge: Möchtest du die Daten von dieser Domain wirklich für immer löschen?
+      content_policies:
+        comment: Nicht-öffentliche Notiz
+        description_html: Du kannst Inhaltsrichtlinien definieren, die auf alle Konten dieser Domain und einer ihrer Subdomains angewendet werden.
+        limited_federation_mode_description_html: Du kannst auswählen, ob du eine Föderation mit dieser Domain erlaubst.
+        policies:
+          reject_media: Medien ablehnen
+          reject_reports: Meldungen ablehnen
+          silence: Stummschaltung
+          suspend: Gesperrt
+        policy: Einschränkung
+        reason: Öffentliche Begründung
+        title: Inhaltsrichtlinien
+      dashboard:
+        instance_accounts_dimension: Meistgefolgte Konten
+        instance_accounts_measure: deren Konten hier im Cache
+        instance_followers_measure: eigene Follower dort
+        instance_follows_measure: deren Follower hier
+        instance_languages_dimension: Häufigste Sprachen
+        instance_media_attachments_measure: deren Medien hier im Cache
+        instance_reports_measure: Meldungen zu deren Konten
+        instance_statuses_measure: deren Beiträge hier im Cache
+      delivery:
+        all: Alle
+        clear: Zustellfehler löschen
+        failing: Fehlerhaft
+        restart: Zustellung neu starten
+        stop: Zustellung beenden
+        unavailable: Nicht verfügbar
+      delivery_available: Zustellung funktioniert
+      delivery_error_days: Tage der fehlerhaften Zustellung
+      delivery_error_hint: Wenn eine Zustellung %{count} Tage lang nicht möglich ist, wird sie automatisch als unzustellbar markiert.
+      destroyed_msg: Daten von %{domain} sind nun in der Warteschlange für die bevorstehende Löschung.
+      empty: Keine Domains gefunden.
+      known_accounts:
+        one: "%{count} bekanntes Konto"
+        other: "%{count} bekannte Konten"
+      moderation:
+        all: Alle
+        limited: Eingeschränkt
+        title: Server
+      moderation_notes:
+        create: Moderationsnotiz hinzufügen
+        created_msg: Moderationsnotiz für diesen Server erfolgreich erstellt!
+        description_html: Hinterlasse Notizen für dich und deine Moderator*innen
+        destroyed_msg: Moderationsnotiz für diesen Server erfolgreich entfernt!
+        placeholder: Informationen über diesen Server, ergriffene Maßnahmen oder andere Sachverhalte, die in Zukunft nützlich sein könnten.
+        title: Moderationsnotizen
+      private_comment: Privater Kommentar
+      public_comment: Öffentlicher Kommentar
+      purge: Säubern
+      purge_description_html: Wenn du glaubst, dass diese Domain endgültig offline ist, dann kannst du alle Kontodatensätze und zugehörigen Daten von diesem Server löschen. Das kann eine Weile dauern.
+      title: Föderation
+      total_blocked_by_us: Von uns gesperrt
+      total_followed_by_them: Gefolgt von denen
+      total_followed_by_us: Gefolgt von uns
+      total_reported: Beschwerden über sie
+      total_storage: Medienanhänge
+      totals_time_period_hint_html: Die unten angezeigten Summen enthalten Daten für alle Zeiten.
+      unknown_instance: Auf diesem Server gibt es derzeit keinen Eintrag dieser Domain.
+    invites:
+      deactivate_all: Alle deaktivieren
+      filter:
+        all: Alle
+        available: Noch gültig
+        expired: Abgelaufen
+        title: Filter
+      title: Einladungen
+    ip_blocks:
+      add_new: Regel erstellen
+      created_msg: Neue IP-Regel erfolgreich hinzugefügt
+      delete: Entfernen
+      expires_in:
+        '1209600': 2 Wochen
+        '15778476': 6 Monate
+        '2629746': 1 Monat
+        '31556952': 1 Jahr
+        '86400': 1 Tag
+        '94670856': 3 Jahre
+      new:
+        title: Neue IP-Regel erstellen
+      no_ip_block_selected: Keine IP-Regeln wurden geändert, weil keine ausgewählt wurde(n)
+      title: IP-Regeln
+    relationships:
+      title: Beziehungen von %{acct}
+    relays:
+      add_new: Neues Relais hinzufügen
+      delete: Entfernen
+      description_html: Ein <strong>Föderierungsrelay</strong> ist ein vermittelnder Server, der eine große Anzahl öffentlicher Beiträge zwischen Servern, die das Relais abonnieren und zu ihm veröffentlichen, austauscht.<strong> Es kann kleinen und mittleren Servern dabei helfen, Inhalte des Fediverse zu entdecken</strong>, was andernfalls das manuelle Folgen anderer Leute auf externen Servern durch lokale Nutzer*innen erfordern würde.
+      disable: Ausschalten
+      disabled: Ausgeschaltet
+      enable: Einschalten
+      enable_hint: Sobald aktiviert, wird dein Server alle öffentlichen Beiträge dieses Relais abonnieren und alle öffentlichen Beiträge dieses Servers an dieses senden.
+      enabled: Eingeschaltet
+      inbox_url: Relay-URL
+      pending: Warte auf Zustimmung des Relays
+      save_and_enable: Speichern und aktivieren
+      setup: Neues Relais verbinden
+      signatures_not_enabled: Die Relais funktionieren nicht korrekt, wenn der abgesicherte Modus aktiviert oder die Föderation eingeschränkt ist
+      status: Status
+      title: Relais
+    report_notes:
+      created_msg: Notiz zur Meldung erfolgreich erstellt!
+      destroyed_msg: Notiz zur Meldung erfolgreich entfernt!
+    reports:
+      account:
+        notes:
+          one: "%{count} Notiz"
+          other: "%{count} Notizen"
+      action_log: Audit-Log
+      action_taken_by: Maßnahme ergriffen von
+      actions:
+        delete_description_html: Der gemeldete Beitrag wird gelöscht und die ergriffene Maßnahme wird aufgezeichnet, um dir bei zukünftigen Verstößen des gleichen Kontos zu helfen.
+        mark_as_sensitive_description_html: Die Medien in den gemeldeten Beiträgen werden mit einer Inhaltswarnung versehen und der Vorfall wird vermerkt, um bei zukünftigen Verstößen desselben Kontos besser reagieren zu können.
+        other_description_html: Weitere Optionen zur Steuerung des Kontoverhaltens und zur Anpassung der Kommunikation mit dem gemeldeten Konto.
+        resolve_description_html: Es wird keine Maßnahme gegen das gemeldete Konto ergriffen und der Vorgang wird nicht aufgezeichnet – die Meldung wird hiermit geschlossen.
+        silence_description_html: Das Konto wird nur für diejenigen sichtbar sein, die dem Konto bereits folgen oder es manuell suchen, was die Reichweite stark einschränkt. Kann jederzeit rückgängig gemacht werden. Alle Meldungen zu diesem Konto werden geschlossen.
+        suspend_description_html: Das Konto und alle Inhalte werden unzugänglich und ggf. gelöscht. Eine Interaktion mit dem Konto wird unmöglich. Dies kann innerhalb von 30 Tagen rückgängig gemacht werden. Alle Meldungen zu diesem Konto werden geschlossen.
+      actions_description_html: Entscheide, welche Maßnahmen du zum Klären dieser Meldung ergreifen möchtest. Wenn du eine Strafmaßnahme gegen das gemeldete Konto ergreifst, wird eine E-Mail-Benachrichtigung an dieses gesendet, außer wenn die <strong>Spam</strong>-Kategorie ausgewählt ist.
+      actions_description_remote_html: Entscheide, welche Maßnahmen du zum Klären dieser Meldung ergreifen möchtest. Dies wirkt sich lediglich darauf aus, wie <strong>dein</strong> Server mit diesem externen Konto kommuniziert und dessen Inhalt handhabt.
+      actions_no_posts: Diese Meldung enthält keine zu löschenden Beiträge
+      add_to_report: Meldung ergänzen
+      already_suspended_badges:
+        local: Auf diesem Server bereits gesperrt
+        remote: Auf dem anderen Server bereits gesperrt
+      are_you_sure: Bist du dir sicher?
+      assign_to_self: Mir zuweisen
+      assigned: Zugewiesene*r Moderator*in
+      by_target_domain: Domain des gemeldeten Kontos
+      cancel: Abbrechen
+      category: Kategorie
+      category_description_html: Der Grund, weshalb dieses Konto und/oder der Inhalt gemeldet worden ist, wird in der Kommunikation mit dem gemeldeten Konto erwähnt
+      comment:
+        none: Kein
+      comment_description_html: "%{name} ergänzte die Meldung um folgende Hinweis:"
+      confirm: Bestätigen
+      confirm_action: Maßnahme gegen @%{acct} bestätigen
+      created_at: Gemeldet
+      delete_and_resolve: Beiträge löschen
+      forwarded: Weitergeleitet
+      forwarded_replies_explanation: Diese Meldung stammt von einem externen Profil und betrifft einen externen Inhalt. Der Inhalt wurde an dich weitergeleitet, weil er eine Antwort auf ein bei dir registriertes Profil ist.
+      forwarded_to: Weitergeleitet an %{domain}
+      mark_as_resolved: Als geklärt markieren
+      mark_as_sensitive: Mit einer Inhaltswarnung versehen
+      mark_as_unresolved: Als ungeklärt markieren
+      no_one_assigned: Niemand
+      notes:
+        create: Notiz hinzufügen
+        create_and_resolve: Mit Notiz als geklärt markieren
+        create_and_unresolve: Mit Notiz wieder öffnen
+        delete: Löschen
+        placeholder: Bitte beschreibe, welche Maßnahmen bzw. Sanktionen ergriffen worden sind, und führe alles auf, was es Erwähnenswertes zu diesem Profil zu berichten gibt …
+        title: Notizen
+      notes_description_html: Notiz an dich und andere Moderator*innen hinterlassen
+      processed_msg: Meldung Nr. %{id} erfolgreich bearbeitet
+      quick_actions_description_html: 'Führe eine schnelle Aktion aus oder scrolle nach unten, um gemeldete Inhalte zu sehen:'
+      remote_user_placeholder: das externe Profil von %{instance}
+      reopen: Meldung wieder eröffnen
+      report: "%{id}. Meldung"
+      reported_account: Gemeldetes Konto
+      reported_by: Gemeldet von
+      reported_with_application: Per App gemeldet
+      resolved: Geklärt
+      resolved_msg: Meldung erfolgreich geklärt!
+      skip_to_actions: Zur Maßnahme springen
+      status: Status
+      statuses: Gemeldeter Inhalt
+      statuses_description_html: Beanstandete Inhalte werden in der Kommunikation mit dem gemeldeten Konto erwähnt
+      summary:
+        action_preambles:
+          delete_html: 'Du bist dabei, einige Beiträge von <strong>@%{acct}</strong> zu <strong>entfernen</strong>. Dies wird:'
+          mark_as_sensitive_html: 'Du bist dabei, einige Beiträge von <strong>@%{acct}</strong> mit einer <strong>Inhaltswarnung</strong> zu <strong>versehen</strong>. Dies wird:'
+          silence_html: 'Du bist dabei, das Konto von <strong>@%{acct}</strong> <strong>einzuschränken</strong>. Dies wird:'
+          suspend_html: 'Du bist dabei, das Konto von <strong>@%{acct}</strong> zu <strong>sperren</strong>. Dies wird:'
+        actions:
+          delete_html: Die beanstandeten Beiträge entfernen
+          mark_as_sensitive_html: Medien der beanstandeten Beiträge mit einer Inhaltswarnung versehen
+          silence_html: Schränkt die Reichweite von <strong>@%{acct}</strong> stark ein, indem das Profil und dessen Inhalte nur für Personen sichtbar sind, die dem Profil bereits folgen oder es manuell aufrufen
+          suspend_html: "<strong>@%{acct}</strong> sperren, sodass das Profil und dessen Inhalte nicht mehr zugänglich sind und keine Interaktion mehr möglich ist"
+        close_report: Meldung Nr. %{id} als geklärt markieren
+        close_reports_html: "<strong>Alle</strong> Meldungen gegen <strong>@%{acct}</strong> als geklärt markieren"
+        delete_data_html: Das Profil und die Inhalte von <strong>@%{acct}</strong> in 30 Tagen löschen, es sei denn, das Konto wird in der Zwischenzeit entsperrt
+        preview_preamble_html: "<strong>@%{acct}</strong> wird eine Warnung mit folgenden Inhalten erhalten:"
+        record_strike_html: Einen Verstoß gegen <strong>@%{acct}</strong> vermerken, um bei zukünftigen Verstößen desselben Kontos besser reagieren zu können
+        send_email_html: "<strong>@%{acct}</strong> eine Warnung per E-Mail senden"
+        warning_placeholder: "(Optional) Zusätzliche Begründung für die Moderationsaktion."
+      target_origin: Domain des gemeldeten Kontos
+      title: Meldungen
+      unassign: Zuweisung aufheben
+      unknown_action_msg: 'Unbekannte Aktion: %{action}'
+      unresolved: Ungeklärt
+      updated_at: Aktualisiert
+      view_profile: Profil anzeigen
+    roles:
+      add_new: Rolle hinzufügen
+      assigned_users:
+        one: "%{count} Konto"
+        other: "%{count} Konten"
+      categories:
+        administration: Administration
+        devops: DevOps
+        invites: Einladungen
+        moderation: Moderation
+        special: Besonderheit
+      delete: Entfernen
+      description_html: Mit <strong>Rollen</strong> kannst du die Funktionen und Bereiche von Mastodon anpassen, auf die deine Benutzer*innen zugreifen können.
+      edit: Rolle „%{name}“ bearbeiten
+      everyone: Standard
+      everyone_full_description_html: Das ist die <strong>Basis-Rolle</strong>, die für <strong>alle Benutzer*innen</strong> gilt – auch für diejenigen ohne zugewiesene Rolle. Alle anderen Rollen erben Berechtigungen davon.
+      permissions_count:
+        one: "%{count} Berechtigung"
+        other: "%{count} Berechtigungen"
+      privileges:
+        administrator: Administrator*in
+        administrator_description: Benutzer*innen mit dieser Berechtigung werden alle Beschränkungen umgehen
+        delete_user_data: Kontodaten löschen
+        delete_user_data_description: Erlaubt Benutzer*innen, die Daten anderer Benutzer*innen sofort zu löschen
+        invite_users: Leute einladen
+        invite_users_description: Erlaubt bereits registrierten Benutzer*innen, neue Leute zum Server einzuladen
+        manage_announcements: Ankündigungen verwalten
+        manage_announcements_description: Erlaubt Profilen, Ankündigungen auf dem Server zu verwalten
+        manage_appeals: Einsprüche verwalten
+        manage_appeals_description: Erlaubt es Benutzer*innen, Entscheidungen der Moderator*innen zu widersprechen
+        manage_blocks: Sperrungen verwalten
+        manage_blocks_description: Erlaubt Nutzer*innen das Sperren von E-Mail-Anbietern und IP-Adressen
+        manage_custom_emojis: Eigene Emojis verwalten
+        manage_custom_emojis_description: Erlaubt es Benutzer*innen, eigene Emojis auf dem Server zu verwalten
+        manage_federation: Föderation verwalten
+        manage_federation_description: Erlaubt Benutzer*innen, Domains anderer Mastodon-Server zu sperren oder zuzulassen – und die Zustellbarkeit zu steuern
+        manage_invites: Einladungen verwalten
+        manage_invites_description: Erlaubt es Benutzer*innen, Einladungslinks zu durchsuchen und zu deaktivieren
+        manage_reports: Meldungen verwalten
+        manage_reports_description: Erlaubt es Benutzer*innen, Meldungen zu überprüfen und Vorfälle zu moderieren
+        manage_roles: Rollen verwalten
+        manage_roles_description: Erlaubt es Benutzer*innen, Rollen, die sich unterhalb der eigenen Rolle befinden, zu verwalten und zuzuweisen
+        manage_rules: Serverregeln verwalten
+        manage_rules_description: Erlaubt es Benutzer*innen, Serverregeln zu ändern
+        manage_settings: Einstellungen verwalten
+        manage_settings_description: Erlaubt Nutzer*innen, Einstellungen dieses Servers zu ändern
+        manage_taxonomies: Hashtags verwalten
+        manage_taxonomies_description: Ermöglicht Benutzer*innen, die Trends zu überprüfen und die Hashtag-Einstellungen zu aktualisieren
+        manage_user_access: Kontozugriff verwalten
+        manage_user_access_description: Erlaubt Nutzer*innen, die Zwei-Faktor-Authentisierung anderer zu deaktivieren, ihre E-Mail-Adresse zu ändern und ihr Passwort zurückzusetzen
+        manage_users: Konten verwalten
+        manage_users_description: Erlaubt es Benutzer*innen, die Details anderer Profile einzusehen und diese Accounts zu moderieren
+        manage_webhooks: Webhooks verwalten
+        manage_webhooks_description: Erlaubt es Benutzer*innen, Webhooks für administrative Vorkommnisse einzurichten
+        view_audit_log: Audit-Log anzeigen
+        view_audit_log_description: Erlaubt es Benutzer*innen, den Verlauf der administrativen Handlungen auf diesem Server einzusehen
+        view_dashboard: Dashboard anzeigen
+        view_dashboard_description: Gewährt Benutzer*innen den Zugriff auf das Dashboard und verschiedene Metriken
+        view_devops: DevOps
+        view_devops_description: Erlaubt es Benutzer*innen, auf die Sidekiq- und pgHero-Dashboards zuzugreifen
+      title: Rollen
+    rules:
+      add_new: Regel hinzufügen
+      add_translation: Übersetzung hinzufügen
+      delete: Löschen
+      description_html: Während die meisten behaupten, die Nutzungsbedingungen tatsächlich gelesen zu haben, bekommen viele sie erst nach einem Problem mit. <strong>Vereinfache und reduziere daher die Serverregeln mit Stichpunkten.</strong> Versuche dabei, die einzelnen Vorgaben kurz und einfach zu halten, aber vermeide, sie in viele verschiedene Elemente aufzuteilen.
+      edit: Regel bearbeiten
+      empty: Es wurden bisher keine Serverregeln definiert.
+      move_down: Abwärts
+      move_up: Aufwärts
+      title: Serverregeln
+      translation: Übersetzung
+      translations: Übersetzungen
+      translations_explanation: Du kannst Serverregeln übersetzen. Der Standardwert wird angezeigt, wenn keine übersetzte Version verfügbar ist. Bitte vergewissere dich, dass jede Übersetzung mit dem Standardwert übereinstimmt.
+    settings:
+      about:
+        manage_rules: Serverregeln verwalten
+        preamble: Schildere ausführlich, wie dein Server betrieben, moderiert und finanziert wird.
+        rules_hint: Es gibt einen eigenen Bereich für Regeln, die deine Benutzer*innen einhalten müssen.
+        title: Über
+      allow_referrer_origin:
+        desc: Klicken Nutzer*innen auf Links zu externen Seiten, kann der Browser die Adresse deines Mastodon-Servers als Referrer (Verweis) übermitteln. Diese Option sollte deaktiviert werden, wenn Nutzer*innen dadurch eindeutig identifiziert würden – z. B. wenn es sich um einen privaten Mastodon-Server handelt.
+        title: Externen Seiten erlauben, diesen Mastodon-Server als Quelle zu sehen
+      appearance:
+        preamble: Passe das Webinterface von Mastodon an.
+        title: Design
+      branding:
+        preamble: Das Branding deines Servers unterscheidet ihn von anderen Servern im Netzwerk. Diese Informationen können in einer Vielzahl von Umgebungen angezeigt werden, z. B. in der Weboberfläche von Mastodon, in nativen Anwendungen, in Linkvorschauen auf anderen Websites und in Messaging-Apps und so weiter. Aus diesem Grund ist es am besten, diese Informationen klar, kurz und prägnant zu halten.
+        title: Branding
+      captcha_enabled:
+        desc_html: Dies beruht auf externen Skripten von hCaptcha, die ein Sicherheits- und Datenschutzproblem darstellen könnten. Darüber hinaus <strong>kann das den Registrierungsprozess für manche Menschen (insbesondere für Menschen mit Behinderung) erheblich erschweren</strong>. Aus diesen Gründen solltest du alternative Maßnahmen in Betracht ziehen, z. B. eine Registrierung basierend auf einer Einladung oder auf Genehmigungen.
+        title: Neue Nutzer*innen müssen ein CAPTCHA lösen, um das Konto zu bestätigen
+      content_retention:
+        danger_zone: Gefahrenzone
+        preamble: Lege fest, wie lange Inhalte von Nutzer*innen auf deinem Mastodon-Server gespeichert bleiben.
+        title: Cache & Archive
+      default_noindex:
+        desc_html: Betrifft alle Profile, die diese Einstellung bei sich nicht geändert haben
+        title: Profile standardmäßig von der Suchmaschinen-Indizierung ausnehmen
+      discovery:
+        follow_recommendations: Follower-Empfehlungen
+        preamble: Das Auffinden interessanter Inhalte ist wichtig, um neue Nutzer einzubinden, die Mastodon noch nicht kennen. Bestimme, wie verschiedene Suchfunktionen auf deinem Server funktionieren.
+        privacy: Datenschutz
+        profile_directory: Profilverzeichnis
+        public_timelines: Öffentliche Timeline
+        publish_statistics: Statistiken veröffentlichen
+        title: Entdecken
+        trends: Trends
+      domain_blocks:
+        all: Allen
+        disabled: Niemandem
+        users: Für angemeldete lokale Benutzer*innen
+      registrations:
+        moderation_recommandation: Bitte vergewissere dich, dass du ein geeignetes und reaktionsschnelles Moderationsteam hast, bevor du die Registrierungen uneingeschränkt zulässt!
+        preamble: Lege fest, wer auf deinem Server ein Konto erstellen darf.
+        title: Registrierungen
+      registrations_mode:
+        modes:
+          approved: Registrierung muss genehmigt werden
+          none: Niemand darf sich registrieren
+          open: Alle können sich registrieren
+        warning_hint: Wir empfehlen die Einstellung „Registrierung muss genehmigt werden“ zu verwenden, es sei denn, du bist dir sicher, dass dein Moderationsteam Spam und böswillige Registrierungen rechtzeitig bearbeiten kann.
+      security:
+        authorized_fetch: Authentisierung von föderierten Servern erforderlich machen
+        authorized_fetch_hint: Das Anfordern einer Authentisierung von föderierten Servern ermöglicht ein strengeres Durchsetzen von Sperren sowohl auf Ebene der Benutzer*innen als auch des Servers. Allerdings ist das mit Leistungseinbußen verbunden, reduziert die Reichweite deiner Antworten und kann zu Kompatibilitätsproblemen mit einigen föderierten Diensten führen. Darüber hinaus wird das Abrufen deiner öffentlichen Beiträge und Konten durch spezialisierte Akteur*innen nicht verhindert.
+        authorized_fetch_overridden_hint: Diese Einstellung wird derzeit von einer Umgebungsvariable überschrieben und kann daher nicht geändert werden.
+        federation_authentication: Authentisierung von föderierten Servern durchsetzen
+      title: Servereinstellungen
+    site_uploads:
+      delete: Hochgeladene Datei löschen
+      destroyed_msg: Upload erfolgreich gelöscht!
+    software_updates:
+      critical_update: Kritisch — bitte zügig aktualisieren
+      description: Es wird empfohlen, deine Mastodon-Installation auf dem aktuellen Stand zu halten, um von den neuesten Fehlerkorrekturen und Funktionen zu profitieren. Darüber hinaus ist es wichtig, Mastodon zeitnah zu aktualisieren, um Sicherheitslücken zu schließen. Aus diesen Gründen prüft Mastodon alle 30 Minuten auf Updates und du wirst deinen Einstellungen entsprechend per E-Mail informiert.
+      documentation_link: Mehr erfahren
+      release_notes: Versionshinweise
+      title: Verfügbare Updates
+      type: Art
+      types:
+        major: Hauptversion
+        minor: Nebenversion
+        patch: Revision — Fehlerkorrekturen und einfach zu implementierende Änderungen
+      version: Version
+    statuses:
+      account: Autor*in
+      application: Anwendung
+      back_to_account: Zurück zum Konto
+      back_to_report: Zurück zur Seite mit den Meldungen
+      batch:
+        add_to_report: Der Meldung Nr. %{id} hinzufügen
+        remove_from_report: Von der Meldung entfernen
+        report: Meldung
+      contents: Inhalte
+      deleted: Gelöscht
+      favourites: Favoriten
+      history: Versionsverlauf
+      in_reply_to: Antwortet auf
+      language: Sprache
+      media:
+        title: Medien
+      metadata: Metadaten
+      no_history: Der Beitrag wurde nicht bearbeitet
+      no_status_selected: Keine Beiträge wurden geändert, weil keine ausgewählt wurden
+      open: Beitrag öffnen
+      original_status: Ursprünglicher Beitrag
+      reblogs: Geteilte Beiträge
+      replied_to_html: Antwortete %{acct_link}
+      status_changed: Beitrag bearbeitet
+      status_title: Beitrag von @%{name}
+      title: Beiträge des Kontos – @%{name}
+      trending: Trends
+      view_publicly: Öffentlich anzeigen
+      visibility: Sichtbarkeit
+      with_media: Mit Medien
+    strikes:
+      actions:
+        delete_statuses: "%{name} entfernte die Beiträge von %{target}"
+        disable: "%{name} fror das Konto von %{target} ein"
+        mark_statuses_as_sensitive: "%{name} hat die Beiträge von %{target} mit einer Inhaltswarnung versehen"
+        none: "%{name} hat eine Warnung an %{target} gesendet"
+        sensitive: "%{name} versah das Konto von %{target} mit einer Inhaltswarnung"
+        silence: "%{name} schaltete das Konto von %{target} stumm"
+        suspend: "%{name} sperrte das Konto von %{target}"
+      appeal_approved: Einspruch angenommen
+      appeal_pending: Einspruch ausstehend
+      appeal_rejected: Einspruch abgelehnt
+    system_checks:
+      database_schema_check:
+        message_html: Es gibt ausstehende Datenbankmigrationen. Bitte führe sie aus, um sicherzustellen, dass sich die Anwendung wie erwartet verhält
+      elasticsearch_analysis_index_mismatch:
+        message_html: 'Die Einstellungen für die Indexanalyse von Elasticsearch sind veraltet. Bitte führe diesen Code aus: <code>tootctl search deploy --only-mapping --only=%{value}</code>'
+      elasticsearch_health_red:
+        message_html: Elasticsearch-Cluster ist fehlerhaft (roter Status) – Suchfunktionen sind nicht verfügbar
+      elasticsearch_health_yellow:
+        message_html: Elasticsearch-Cluster ist fehlerhaft (gelber Status) – du solltest den Grund dafür untersuchen
+      elasticsearch_index_mismatch:
+        message_html: 'Elasticsearch-Index-Mappings sind veraltet. Bitte führe Folgendes aus: <code>tootctl search deploy --only=%{value}</code>'
+      elasticsearch_preset:
+        action: Dokumentation ansehen
+        message_html: Elasticsearch-Cluster besitzt mehr als einen Knoten, aber Mastodon ist nicht für die Verwendung dieser Knoten konfiguriert.
+      elasticsearch_preset_single_node:
+        action: Dokumentation ansehen
+        message_html: Elasticsearch-Cluster besitzt nur einen Knoten. <code>ES_PRESET</code> sollte auf <code>single_node_cluster</code> gesetzt werden.
+      elasticsearch_reset_chewy:
+        message_html: 'Elasticsearch-Systemindex ist aufgrund einer Einstellungsänderung veraltet. Bitte führe Folgendes zum Aktualisieren aus: <code>tootctl search deploy --reset-chewy</code>'
+      elasticsearch_running_check:
+        message_html: Verbindung mit Elasticsearch konnte nicht hergestellt werden. Bitte prüfe, ob Elasticsearch läuft, oder deaktiviere die Volltextsuche
+      elasticsearch_version_check:
+        message_html: 'Inkompatible Elasticsearch-Version: %{value}'
+        version_comparison: Elasticsearch %{running_version} läuft, aber %{required_version} wird benötigt
+      rules_check:
+        action: Serverregeln verwalten
+        message_html: Du hast keine Serverregeln festgelegt.
+      sidekiq_process_check:
+        message_html: Kein Sidekiq-Prozess läuft für die %{value} Warteschlange(n). Bitte überprüfe deine Sidekiq-Konfiguration
+      software_version_check:
+        action: Verfügbare Updates ansehen
+        message_html: Ein Mastodon-Update ist verfügbar.
+      software_version_critical_check:
+        action: Verfügbare Updates ansehen
+        message_html: Ein kritisches Mastodon-Update ist verfügbar – bitte aktualisiere so schnell wie möglich.
+      software_version_patch_check:
+        action: Verfügbare Updates ansehen
+        message_html: Ein Mastodon-Update für Fehlerkorrekturen ist verfügbar.
+      upload_check_privacy_error:
+        action: Für weitere Informationen hier klicken
+        message_html: "<strong>Die Konfiguration deines Servers ist fehlerhaft. Die Privatsphäre deiner Benutzer*innen ist gefährdet.</strong>"
+      upload_check_privacy_error_object_storage:
+        action: Für weitere Informationen hier klicken
+        message_html: "<strong>Die Konfiguration deines Objektspeichers ist fehlerhaft. Die Privatsphäre deiner Benutzer*innen ist gefährdet.</strong>"
+    tags:
+      moderation:
+        not_trendable: Nicht trendfähig
+        not_usable: Nicht verwendbar
+        pending_review: Überprüfung ausstehend
+        review_requested: Überprüfung angefordert
+        reviewed: Überprüft
+        title: Status
+        trendable: Trendfähig
+        unreviewed: Ungeprüft
+        usable: Verwendbar
+      name: Name
+      newest: Neueste
+      oldest: Älteste
+      open: Öffentlich anzeigen
+      reset: Zurücksetzen
+      review: Prüfstatus
+      search: Suchen
+      title: Hashtags
+      updated_msg: Hashtag-Einstellungen erfolgreich aktualisiert
+    terms_of_service:
+      back: Zurück zu den Nutzungsbedingungen
+      changelog: Was sich geändert hat
+      create: Eigene erstellen
+      current: Aktuell
+      draft: Entwurf
+      generate: Vorlage verwenden
+      generates:
+        action: Erstellen
+        chance_to_review_html: "<strong>Die durch diese Vorlage erstellten Nutzungsbedingungen werden nicht automatisch veröffentlicht.</strong> Du wirst alles noch einmal überprüfen können. Bitte fülle alle Felder mit den notwendigen Informationen aus, um fortzufahren."
+        explanation_html: Die Vorlage für die Nutzungsbedingungen dient ausschließlich zu Informationszwecken und sollte nicht als Rechtsberatung zu einem bestimmten Thema verstanden werden. Bei rechtlichen Fragen, konsultiere bitte deinen Rechtsbeistand.
+        title: Nutzungsbedingungen festlegen
+      going_live_on_html: Aktuell gültig (ab %{date})
+      history: Verlauf
+      live: Aktuell gültig
+      no_history: Es wurden noch keine Änderungen an den Nutzungsbedingungen aufgezeichnet.
+      no_terms_of_service_html: Du hast derzeit keine Nutzungsbedingungen bereitgestellt. Nutzungsbedingungen verschaffen Klarheit und schützen vor möglicher Haftung bei Streitigkeiten mit deinen Nutzer*innen.
+      notified_on_html: Nutzer*innen wurden am %{date} benachrichtigt
+      notify_users: Nutzer*innen benachrichtigen
+      preview:
+        explanation_html: 'Die E-Mail wird an <strong>%{display_count} Nutzer*innen</strong> gesendet, die sich vor dem %{date} registriert haben. Folgendes wird in der E-Mail enthalten sein:'
+        send_preview: Vorschau an %{email} senden
+        send_to_all:
+          one: "%{display_count} E-Mail senden"
+          other: "%{display_count} E-Mails senden"
+        title: Vorschau zu den neuen Nutzungsbedingungen
+      publish: Veröffentlichen
+      published_on_html: Veröffentlicht am %{date}
+      save_draft: Entwurf speichern
+      title: Nutzungsbedingungen
+    title: Administration
+    trends:
+      allow: Erlauben
+      approved: Freigegeben
+      confirm_allow: Möchtest du die ausgewählten Tags wirklich erlauben?
+      confirm_disallow: Möchtest du die ausgewählten Tags wirklich verbieten?
+      disallow: Verbieten
+      links:
+        allow: Link erlauben
+        allow_provider: Herausgeber*in erlauben
+        confirm_allow: Möchtest du die ausgewählten Links wirklich erlauben?
+        confirm_allow_provider: Möchtest du die ausgewählten Anbieter wirklich erlauben?
+        confirm_disallow: Möchtest du die ausgewählten Links wirklich verbieten?
+        confirm_disallow_provider: Möchtest du die ausgewählten Anbieter wirklich verbieten?
+        description_html: Dies sind Links, die derzeit von zahlreichen Konten geteilt werden und die deinem Server aufgefallen sind. Die Benutzer*innen können darüber herausfinden, was in der Welt vor sich geht. Die Links werden allerdings erst dann öffentlich vorgeschlagen, wenn du die Herausgeber*innen genehmigt hast. Du kannst alternativ aber auch nur einzelne URLs zulassen oder ablehnen.
+        disallow: Link verbieten
+        disallow_provider: Herausgeber*in verbieten
+        no_link_selected: Keine Links wurden geändert, da keine ausgewählt wurden
+        publishers:
+          no_publisher_selected: Keine Herausgeber*innen wurden geändert, da keine ausgewählt wurden
+        shared_by_over_week:
+          one: In den vergangenen 7 Tagen von einem Profil geteilt
+          other: In den vergangenen 7 Tagen von %{count} Profilen geteilt
+        title: Angesagte Links
+        usage_comparison: Heute %{today}-mal und gestern %{yesterday}-mal geteilt
+      not_allowed_to_trend: Darf nicht trenden
+      only_allowed: Nur Genehmigte
+      pending_review: Überprüfung ausstehend
+      preview_card_providers:
+        allowed: Links von diesem/dieser Herausgeber*in können im Trend liegen
+        description_html: Dies sind Domains, von denen Links oft auf deinem Server geteilt werden. Links werden nicht öffentlich trenden, es sei denn, die Domain des Links wird genehmigt. Deine Zustimmung (oder Ablehnung) erstreckt sich auf Subdomains.
+        rejected: Links von diesem/dieser Herausgeber*in werden nicht im Trend liegen
+        title: Herausgeber
+      rejected: Abgelehnt
+      statuses:
+        allow: Beitrag erlauben
+        allow_account: Profil erlauben
+        confirm_allow: Möchtest du die ausgewählten Status wirklich erlauben?
+        confirm_allow_account: Möchtest du die ausgewählten Konten wirklich erlauben?
+        confirm_disallow: Möchtest du die ausgewählten Status wirklich verbieten?
+        confirm_disallow_account: Möchtest du die ausgewählten Konten wirklich verbieten?
+        description_html: Dies sind Beiträge, von denen dein Server weiß, dass sie derzeit viel geteilt und favorisiert werden. Dies kann neuen und wiederkehrenden Personen helfen, weitere Profile zu finden, denen sie folgen können. Die Beiträge werden erst dann öffentlich angezeigt, wenn du die Person genehmigst und sie es zulässt, dass ihr Profil anderen vorgeschlagen wird. Du kannst auch einzelne Beiträge zulassen oder ablehnen.
+        disallow: Beitrag verbieten
+        disallow_account: Profil verweigern
+        no_status_selected: Die im Trend liegenden Beiträge wurden nicht geändert, da keine ausgewählt wurden
+        not_discoverable: Autor*in hat sich dafür entschieden, nicht entdeckt zu werden
+        shared_by:
+          one: Einmal geteilt oder favorisiert
+          other: "%{friendly_count}-mal geteilt oder favorisiert"
+        title: Angesagte Beiträge
+      tags:
+        current_score: 'Aktueller Score: %{score}'
+        dashboard:
+          tag_accounts_measure: Profile
+          tag_languages_dimension: Häufigste Sprachen
+          tag_servers_dimension: Aktivste Server
+          tag_servers_measure: Server
+          tag_uses_measure: insgesamt
+        description_html: Diese Hashtags werden derzeit in vielen Beiträgen verwendet, die dein Server sieht. Dies kann deinen Nutzer*innen helfen, herauszufinden, worüber die Leute im Moment am meisten schreiben. Hashtags werden erst dann öffentlich angezeigt, wenn du sie genehmigst.
+        listable: Kann vorgeschlagen werden
+        no_tag_selected: Keine Hashtags wurden geändert, da keine ausgewählt wurden
+        not_listable: Wird nicht vorgeschlagen
+        not_trendable: Wird in den Trends nicht angezeigt
+        not_usable: Kann nicht verwendet werden
+        peaked_on_and_decaying: In den Trends am %{date}, jetzt absteigend
+        title: Angesagte Hashtags
+        trendable: Darf in den Trends erscheinen
+        trending_rank: Platz %{rank}
+        usable: Darf verwendet werden
+        usage_comparison: Heute %{today}-mal und gestern %{yesterday}-mal verwendet
+        used_by_over_week:
+          one: In den vergangenen 7 Tagen von einem Profil verwendet
+          other: In den vergangenen 7 Tagen von %{count} Profilen verwendet
+      title: Empfehlungen & Trends
+      trending: Angesagt
+    username_blocks:
+      add_new: Neue Regel
+      block_registrations: Registrierungen sperren
+      comparison:
+        contains: Enthält
+        equals: Entspricht
+      contains_html: Enthält %{string}
+      created_msg: Regel für Profilnamen erfolgreich erstellt
+      delete: Löschen
+      edit:
+        title: Regel für Profilnamen bearbeiten
+      matches_exactly_html: Entspricht %{string}
+      new:
+        create: Regel erstellen
+        title: Neue Regel für Profilnamen erstellen
+      no_username_block_selected: Keine Regeln für Profilnamen wurden geändert, weil keine ausgewählt wurde(n)
+      not_permitted: Nicht gestattet
+      title: Regeln für Profilnamen
+      updated_msg: Regel für Profilnamen erfolgreich aktualisiert
+    warning_presets:
+      add_new: Neu hinzufügen
+      delete: Löschen
+      edit_preset: Warnvorlage bearbeiten
+      empty: Du hast noch keine Warnvorlagen hinzugefügt.
+      title: Warnvorlagen
+    webhooks:
+      add_new: Endpunkt hinzufügen
+      delete: Löschen
+      description_html: Ein <strong>Webhook</strong> ermöglicht Mastodon, <strong>Echtzeitbenachrichtigungen</strong> über ausgewählte Ereignisse an deine eigene Anwendung zu senden, damit deine Anwendung <strong>automatisch Reaktionen auslösen kann</strong>.
+      disable: Deaktivieren
+      disabled: Deaktiviert
+      edit: Endpunkt bearbeiten
+      empty: Du hast noch keine Webhook-Endpunkte konfiguriert.
+      enable: Aktivieren
+      enabled: Aktiv
+      enabled_events:
+        one: 1 aktiviertes Ereignis
+        other: "%{count} aktivierte Ereignisse"
+      events: Ereignisse
+      new: Neuer Webhook
+      rotate_secret: Geheimen Schlüssel rotieren
+      secret: Signaturgeheimnis
+      status: Status
+      title: Webhooks
+      webhook: Webhook
+  admin_mailer:
+    auto_close_registrations:
+      body: Aufgrund fehlender Aktivität von Moderator*innen müssen neue Registrierungen auf %{instance} jetzt manuell genehmigt werden. Dies wurde automatisch umgestellt, damit %{instance} nicht als Plattform für Böswillige missbraucht werden kann. Du kannst jederzeit auf uneingeschränkte Registrierungen zurückwechseln.
+      subject: Registrierungen auf %{instance} müssen ab jetzt manuell genehmigt werden (automatisch umgestellt)
+    new_appeal:
+      actions:
+        delete_statuses: das Löschen der Beiträge
+        disable: das Einfrieren der Konten
+        mark_statuses_as_sensitive: um die Beiträge des Profils mit einer Inhaltswarnung zu versehen
+        none: eine Warnung
+        sensitive: das Markieren des Kontos mit einer Inhaltswarnung
+        silence: das Beschränken des Kontos
+        suspend: um deren Konto zu sperren
+      body: "%{target} erhebt Einspruch gegen eine Moderationsentscheidung von %{action_taken_by} vom %{date} (%{type}). Folgendes wurde geschrieben:"
+      next_steps: Du kannst dem Einspruch zustimmen, um die Moderationsentscheidung rückgängig zu machen, oder ihn ignorieren.
+      subject: "%{username} hat Einspruch gegen eine Moderationsentscheidung auf %{instance} erhoben"
+    new_critical_software_updates:
+      body: ein neues Sicherheitsupdate wurde veröffentlicht. Du solltest Mastodon so schnell wie möglich aktualisieren!
+      subject: Kritische Mastodon-Updates sind für %{instance} verfügbar!
+    new_pending_account:
+      body: Die Details von diesem neuem Konto sind unten. Du kannst die Anfrage akzeptieren oder ablehnen.
+      subject: Neues Konto zum Überprüfen auf %{instance} verfügbar (%{username})
+    new_report:
+      body: "%{reporter} hat %{target} gemeldet"
+      body_remote: Jemand von %{domain} hat %{target} gemeldet
+      subject: Neue Meldung auf %{instance} (Nr. %{id})
+    new_software_updates:
+      body: Neue Mastodon-Versionen wurden veröffentlicht – du solltest aktualisieren!
+      subject: Neue Mastodon-Versionen sind für %{instance} verfügbar!
+    new_trends:
+      body: 'Die folgenden Einträge müssen überprüft werden, bevor sie öffentlich angezeigt werden können:'
+      new_trending_links:
+        title: Angesagte Links
+      new_trending_statuses:
+        title: Angesagte Beiträge
+      new_trending_tags:
+        title: Angesagte Hashtags
+      subject: Neue Trends zur Überprüfung auf %{instance}
+  aliases:
+    add_new: Alias erstellen
+    created_msg: Neuer Alias erfolgreich erstellt. Du kannst nun den Umzug vom alten zum neuen Konto starten.
+    deleted_msg: Der Alias wurde erfolgreich entfernt. Aus jenem Konto zu diesem zu verschieben, ist nicht mehr möglich.
+    empty: Du hast keine Aliasse.
+    hint_html: Wenn du von einem anderen Konto auf dieses umziehen möchtest, dann kannst du hier einen Alias erstellen, der erforderlich ist, um deine Follower vom alten Konto auf dieses zu migrieren. Diese Aktion ist <strong>harmlos und wi­der­ruf­lich</strong>. <strong>Der Kontoumzug wird vom alten Konto aus eingeleitet</strong>.
+    remove: Alle Aliasse aufheben
+  appearance:
+    advanced_web_interface: Erweitertes Webinterface
+    advanced_web_interface_hint: Wenn du mehr aus deiner Bildschirmbreite herausholen möchtest, kannst du mit dem erweiterten Webinterface weitere Spalten hinzufügen und dadurch mehr Informationen auf einmal sehen, z. B. deine Startseite, die Benachrichtigungen, die föderierte Timeline sowie beliebig viele deiner Listen und Hashtags.
+    animations_and_accessibility: Animationen und Barrierefreiheit
+    confirmation_dialogs: Bestätigungsdialoge
+    discovery: Entdecken
+    localization:
+      body: Mastodon wird von Freiwilligen übersetzt.
+      guide_link: https://de.crowdin.com/project/mastodon/de
+      guide_link_text: Alle können mitmachen und etwas dazu beitragen.
+    sensitive_content: Inhaltswarnung
+  application_mailer:
+    notification_preferences: E-Mail-Einstellungen ändern
+    salutation: "%{name},"
+    settings: 'E-Mail-Einstellungen ändern: %{link}'
+    unsubscribe: Abbestellen
+    view: 'Siehe:'
+    view_profile: Profil anzeigen
+    view_status: Beitrag anschauen
+  applications:
+    created: Anwendung erfolgreich erstellt
+    destroyed: Anwendung erfolgreich gelöscht
+    logout: Abmelden
+    regenerate_token: Zugriffstoken neu erstellen
+    token_regenerated: Zugriffstoken erfolgreich neu erstellt
+    warning: Sei mit diesen Daten sehr vorsichtig. Teile sie mit niemandem!
+    your_token: Dein Zugriffstoken
+  auth:
+    apply_for_account: Konto beantragen
+    captcha_confirmation:
+      help_html: Falls du Probleme beim Lösen des CAPTCHA hast, dann kannst uns über %{email} kontaktieren und wir werden versuchen, dir zu helfen.
+      hint_html: Fast geschafft! Wir müssen uns vergewissern, dass du ein Mensch bist (damit wir Spam verhindern können!). Bitte löse das CAPTCHA und klicke auf „Fortfahren“.
+      title: Sicherheitsüberprüfung
+    confirmations:
+      awaiting_review: Deine E-Mail-Adresse wurde bestätigt und das Team von %{domain} überprüft nun deine Registrierung. Sobald es dein Konto genehmigt, wirst du eine E-Mail erhalten!
+      awaiting_review_title: Deine Registrierung wird überprüft
+      clicking_this_link: Klick auf diesen Link
+      login_link: anmelden
+      proceed_to_login_html: Du kannst dich nun %{login_link}.
+      redirect_to_app_html: Du hättest zur <strong>%{app_name}</strong>-App weitergeleitet werden sollen. Wenn das nicht geschehen ist, versuche es mit einem %{clicking_this_link} oder kehre manuell zur App zurück.
+      registration_complete: Deine Registrierung auf %{domain} ist nun abgeschlossen!
+      welcome_title: Willkommen, %{name}!
+      wrong_email_hint: Wenn diese E-Mail-Adresse nicht korrekt ist, kann sie in den Kontoeinstellungen geändert werden.
+    delete_account: Konto löschen
+    delete_account_html: Falls du dein Konto endgültig löschen möchtest, kannst du das <a href="%{path}">hier vornehmen</a>. Du musst dies zusätzlich bestätigen.
+    description:
+      prefix_invited_by_user: "@%{name} lädt dich ein, diesem Mastodon-Server beizutreten!"
+      prefix_sign_up: Registriere dich noch heute bei Mastodon!
+      suffix: Mit einem Konto kannst du Profilen folgen, neue Beiträge veröffentlichen, Nachrichten mit Personen von jedem Mastodon-Server austauschen und vieles mehr!
+    didnt_get_confirmation: Keinen Bestätigungslink erhalten?
+    dont_have_your_security_key: Du hast keinen Sicherheitsschlüssel?
+    forgot_password: Passwort vergessen?
+    invalid_reset_password_token: Das Token zum Zurücksetzen des Passworts ist ungültig oder abgelaufen. Bitte fordere ein neues an.
+    link_to_otp: Gib einen Zwei-Faktor-Code von deinem Smartphone oder einen Wiederherstellungscode ein
+    link_to_webauth: Verwende deinen Sicherheitsschlüssel
+    log_in_with: Anmelden mit
+    login: Anmelden
+    logout: Abmelden
+    migrate_account: Zu einem anderen Konto umziehen
+    migrate_account_html: Wenn du dieses Konto auf ein anderes weiterleiten möchtest, kannst du es <a href="%{path}">hier konfigurieren</a>.
+    or_log_in_with: Oder anmelden mit
+    progress:
+      confirm: E-Mail bestätigen
+      details: Deine Daten
+      review: Unsere Überprüfung
+      rules: Regeln akzeptieren
+    providers:
+      cas: CAS
+      saml: SAML
+    register: Registrieren
+    registration_closed: "%{instance} akzeptiert keine neuen Mitglieder"
+    resend_confirmation: Bestätigungslink erneut zusenden
+    reset_password: Passwort zurücksetzen
+    rules:
+      accept: Akzeptieren
+      back: Zurück
+      invited_by: 'Du kannst %{domain} beitreten – dank der Einladung von:'
+      preamble: Diese werden von den Moderator*innen von %{domain} festgelegt und durchgesetzt.
+      preamble_invited: Bevor du fortfährst, beachte bitte die Grundregeln der Moderator*innen von %{domain}.
+      title: Einige Grundregeln.
+      title_invited: Du wurdest eingeladen.
+    security: Sicherheit
+    set_new_password: Neues Passwort einrichten
+    setup:
+      email_below_hint_html: Überprüfe deinen Spam-Ordner oder lass dir den Bestätigungslink erneut zusenden. Falls die angegebene E-Mail-Adresse falsch ist, kannst du sie auch korrigieren.
+      email_settings_hint_html: Klicke auf den Link, den wir an %{email} gesendet haben, um mit Mastodon loszulegen. Wir warten hier solange auf dich.
+      link_not_received: Keinen Bestätigungslink erhalten?
+      new_confirmation_instructions_sent: In wenigen Minuten wirst du eine neue E-Mail mit dem Bestätigungslink erhalten!
+      title: Überprüfe dein E-Mail-Postfach
+    sign_in:
+      preamble_html: Melde dich mit deinen Zugangsdaten für <strong>%{domain}</strong> an. Falls dein Konto auf einem anderen Server erstellt wurde, ist eine Anmeldung hier nicht möglich.
+      title: Bei %{domain} anmelden
+    sign_up:
+      manual_review: Registrierungen für den Server %{domain} werden manuell durch unsere Moderator*innen überprüft. Um uns dabei zu unterstützen, schreibe etwas über dich und sage uns, weshalb du ein Konto auf %{domain} anlegen möchtest.
+      preamble: Mit einem Konto auf diesem Mastodon-Server kannst du jeder anderen Person im Fediverse folgen, unabhängig davon, wo ihr Konto registriert ist.
+      title: Lass uns dein Konto auf %{domain} einrichten.
+    status:
+      account_status: Kontostatus
+      confirming: Auf die Bestätigung deiner E-Mail-Adresse wird gewartet.
+      functional: Dein Konto ist voll funktionsfähig.
+      pending: Die Prüfung deiner Bewerbung steht noch aus und kann einige Zeit in Anspruch nehmen. Sobald deine Bewerbung genehmigt wurde, erhältst du eine E-Mail.
+      redirecting_to: Dein Konto ist inaktiv, weil es zu %{acct} umgezogen ist.
+      self_destruct: Da %{domain} den Betrieb einstellen wird, wirst du nur begrenzten Zugriff auf dein Konto haben.
+      view_strikes: Vorherige Verstöße deines Kontos ansehen
+    too_fast: Formular zu schnell übermittelt. Bitte versuche es erneut.
+    use_security_key: Sicherheitsschlüssel verwenden
+    user_agreement_html: Ich stimme den <a href="%{terms_of_service_path}" target="_blank">Nutzungsbedingungen</a> sowie der <a href="%{privacy_policy_path}" target="_blank">Datenschutzerklärung</a> zu
+    user_privacy_agreement_html: Ich stimme der <a href="%{privacy_policy_path}" target="_blank">Datenschutzerklärung</a> zu
+  author_attribution:
+    example_title: Beispieltitel
+    hint_html: Schreibst du außerhalb von Mastodon journalistische Artikel oder andere Texte, beispielsweise in einem Blog? Lege hier fest, wann auf dein Profil verwiesen werden soll, wenn Links zu deinen Werken auf Mastodon geteilt werden.
+    instructions: 'Der nachfolgende Code muss im HTML-Header deines zu verlinkenden Textes stehen:'
+    more_from_html: Mehr von %{name}
+    s_blog: Blog von %{name}
+    then_instructions: Ergänze anschließend im unteren Feld die Domain, auf der sich deine Inhalte befinden.
+    title: Verifizierung als Autor*in
+  challenge:
+    confirm: Fortfahren
+    hint_html: "<strong>Hinweis:</strong> Wir werden dich für die nächste Stunde nicht erneut nach deinem Passwort fragen."
+    invalid_password: Ungültiges Passwort
+    prompt: Bestätige mit deinem Passwort, um fortzufahren
+  crypto:
+    errors:
+      invalid_key: ist kein gültiger Ed25519- oder Curve25519-Schlüssel
+  date:
+    formats:
+      default: "%d. %b %Y"
+      with_month_name: "%d. %B %Y"
+  datetime:
+    distance_in_words:
+      about_x_hours: "%{count} Std."
+      about_x_months: "%{count} Mon."
+      about_x_years: "%{count} J."
+      almost_x_years: "%{count} J."
+      half_a_minute: Gerade eben
+      less_than_x_minutes: "%{count} Min."
+      less_than_x_seconds: Gerade eben
+      over_x_years: "%{count} J."
+      x_days: "%{count} T."
+      x_minutes: "%{count} Min."
+      x_months: "%{count} Mon."
+      x_seconds: "%{count} Sek."
+  deletes:
+    challenge_not_passed: Die eingegebenen Informationen waren nicht korrekt
+    confirm_password: Gib dein derzeitiges Passwort ein, um deine Identität zu bestätigen
+    confirm_username: Gib deinen Profilnamen ein, um den Vorgang zu bestätigen
+    proceed: Konto löschen
+    success_msg: Dein Konto wurde erfolgreich gelöscht
+    warning:
+      before: 'Bevor du fortfährst, lies bitte diese Hinweise sorgfältig durch:'
+      caches: Inhalte, die von anderen Servern zwischengespeichert wurden, können fortbestehen
+      data_removal: Deine Beiträge und alle anderen Daten werden für immer entfernt
+      email_change_html: Du kannst <a href="%{path}">deine E-Mail-Adresse ändern</a>, ohne dein Konto zu löschen
+      email_contact_html: Wenn die Bestätigungs-E-Mail immer noch nicht ankam, kannst du eine E-Mail an <a href="mailto:%{email}">%{email}</a> senden, um weitere Hilfe zu erhalten
+      email_reconfirmation_html: Wenn du die Bestätigungs-E-Mail nicht erhalten hast, kannst du sie <a href="%{path}">erneut anfordern</a>
+      irreversible: Du wirst dein Konto nicht mehr wiederherstellen oder reaktivieren können
+      more_details_html: Weitere Details findest du in der <a href="%{terms_path}">Datenschutzerklärung</a>.
+      username_available: Dein Profilname wird wieder verfügbar sein
+      username_unavailable: Dein Profilname wird auch nach dem Löschen für andere nicht zugänglich sein
+  disputes:
+    strikes:
+      action_taken: Maßnahme
+      appeal: Einspruch
+      appeal_approved: Dieser Verstoß wurde erfolgreich angefochten und ist nicht mehr gültig
+      appeal_rejected: Der Einspruch wurde abgelehnt
+      appeal_submitted_at: Einspruch eingereicht
+      appealed_msg: Dein Einspruch wurde übermittelt. Wenn er angenommen wird, wirst du benachrichtigt.
+      appeals:
+        submit: Einspruch erheben
+      approve_appeal: Einspruch annehmen
+      associated_report: Zugehörige Meldung
+      created_at: Datum
+      description_html: Dies sind Maßnahmen, die gegen dein Konto ergriffen worden sind, und Warnungen, die dir die Mitarbeiter*innen von %{instance} gesendet haben.
+      recipient: Adressiert an
+      reject_appeal: Einspruch ablehnen
+      status: "%{id}. Beitrag"
+      status_removed: Beitrag bereits vom System entfernt
+      title: "%{action} vom %{date}"
+      title_actions:
+        delete_statuses: Beitragsentfernung
+        disable: Konto einfrieren
+        mark_statuses_as_sensitive: Beiträge mit einer Inhaltswarnung versehen
+        none: Warnung
+        sensitive: Profil mit einer Inhaltswarnung versehen
+        silence: Kontobeschränkung
+        suspend: Kontosperre
+      your_appeal_approved: Dein Einspruch wurde angenommen
+      your_appeal_pending: Du hast Einspruch erhoben
+      your_appeal_rejected: Dein Einspruch wurde abgelehnt
+  edit_profile:
+    basic_information: Allgemeine Informationen
+    hint_html: "<strong>Bestimme, was andere auf deinem öffentlichen Profil und neben deinen Beiträgen sehen können.</strong> Wenn du ein Profilbild festlegst und dein Profil vervollständigst, werden andere eher mit dir interagieren und dir folgen."
+    other: Andere
+  emoji_styles:
+    auto: Automatisch
+    native: Nativ
+    twemoji: Twemoji
+  errors:
+    '400': Die Anfrage, die du gestellt hast, war ungültig oder fehlerhaft.
+    '403': Dir fehlt die Berechtigung, diese Seite aufzurufen.
+    '404': Die Seite, nach der du gesucht hast, wurde nicht gefunden.
+    '406': Diese Seite ist im gewünschten Format nicht verfügbar.
+    '410': Die Seite, nach der du gesucht hast, existiert hier nicht mehr.
+    '422':
+      content: Sicherheitsüberprüfung fehlgeschlagen. Blockierst du Cookies?
+      title: Sicherheitsüberprüfung fehlgeschlagen
+    '429': Zu viele Anfragen
+    '500':
+      content: Wir bitten um Verzeihung, aber etwas ist bei uns schiefgegangen.
+      title: Diese Seite enthält einen Fehler
+    '503': Die Seite konnte wegen eines temporären Serverfehlers nicht angezeigt werden.
+    noscript_html: Bitte aktiviere JavaScript, um das Webinterface von Mastodon zu verwenden. Alternativ kannst du auch eine der <a href="%{apps_path}">nativen Apps</a> für Mastodon verwenden.
+  existing_username_validator:
+    not_found: kann lokale Konten mit diesem Profilnamen nicht finden
+    not_found_multiple: "%{usernames} konnten nicht gefunden werden"
+  exports:
+    archive_takeout:
+      date: Datum
+      download: Archiv jetzt herunterladen
+      hint_html: Du kannst ein Archiv deiner <strong>Beiträge, Listen, hochgeladenen Medien usw.</strong> anfordern. Die exportierten Daten werden im ActivityPub-Format gespeichert und können mit geeigneter Software ausgewertet und angezeigt werden. Du kannst alle 7 Tage ein Archiv erstellen lassen.
+      in_progress: Persönliches Archiv wird erstellt …
+      request: Dein Archiv anfordern
+      size: Dateigröße
+    blocks: Blockierte Profile
+    bookmarks: Lesezeichen
+    csv: CSV
+    domain_blocks: Blockierte Domains
+    lists: Listen
+    mutes: Stummgeschaltete Profile
+    storage: Medienspeicher
+  featured_tags:
+    add_new: Neuen hinzufügen
+    errors:
+      limit: Du hast bereits die maximale Anzahl an Hashtags erreicht
+    hint_html: "<strong>Präsentiere deine wichtigsten Hashtags auf deinem Profil.</strong> Vorgestellte Hashtags verschaffen einen Überblick über deine kreativen Werke und langfristigen Projekte. Sie werden gut sichtbar auf deinem Profil angezeigt und ermöglichen einen schnellen Zugriff auf deine eigenen Beiträge."
+  filters:
+    contexts:
+      account: Profile
+      home: Startseite und Listen
+      notifications: Benachrichtigungen
+      public: Öffentliche Timelines
+      thread: Private Erwähnungen
+    edit:
+      add_keyword: Schlagwort hinzufügen
+      keywords: Schlagwörter
+      statuses: Individuelle Beiträge
+      statuses_hint_html: Dieser Filter gilt für die Auswahl einzelner Beiträge, unabhängig davon, ob sie mit den unten aufgeführten Schlagwörtern übereinstimmen. <a href="%{path}">Beiträge überprüfen oder aus dem Filter entfernen</a>.
+      title: Filter bearbeiten
+    errors:
+      deprecated_api_multiple_keywords: Diese Parameter können von dieser Anwendung nicht geändert werden, da sie für mehr als ein Filterschlagwort gelten. Verwende eine aktuellere Anwendung oder das Webinterface.
+      invalid_context: Ungültiger oder fehlender Kontext übergeben
+    index:
+      contexts: Filter in %{contexts}
+      delete: Löschen
+      empty: Du hast noch keine Filter erstellt.
+      expires_in: Läuft ab in %{distance}
+      expires_on: Läuft am %{date} ab
+      keywords:
+        one: "%{count} Schlagwort"
+        other: "%{count} Schlagwörter"
+      statuses:
+        one: "%{count} Beitrag"
+        other: "%{count} Beiträge"
+      statuses_long:
+        one: "%{count} individueller Beitrag ausgeblendet"
+        other: "%{count} individuelle Beiträge ausgeblendet"
+      title: Filter
+    new:
+      save: Neuen Filter speichern
+      title: Neuen Filter hinzufügen
+    statuses:
+      back_to_filter: Zurück zu den Filtern
+      batch:
+        remove: Filter entfernen
+      index:
+        hint: Dieser Filter wird verwendet, um einzelne Beiträge unabhängig von anderen Kriterien auszuwählen. Du kannst mehr Beiträge zu diesem Filter über das Webinterface hinzufügen.
+        title: Gefilterte Beiträge
+  generic:
+    all: Alle
+    all_items_on_page_selected_html:
+      one: "<strong>%{count}</strong> Element auf dieser Seite ausgewählt."
+      other: Alle <strong>%{count}</strong> Elemente auf dieser Seite ausgewählt.
+    all_matching_items_selected_html:
+      one: "<strong>%{count}</strong> Element, das den Suchkriterien entspricht, ist ausgewählt."
+      other: Alle <strong>%{count}</strong> Elemente, die den Suchkriterien entsprechen, sind ausgewählt.
+    cancel: Abbrechen
+    changes_saved_msg: Änderungen erfolgreich gespeichert!
+    confirm: Bestätigen
+    copy: Kopieren
+    delete: Löschen
+    deselect: Alle abwählen
+    none: Keine
+    order_by: Sortieren nach
+    save_changes: Änderungen speichern
+    select_all_matching_items:
+      one: Wähle %{count} Element, das deinen Suchkriterien entspricht.
+      other: Wähle alle %{count} Elemente, die deinen Suchkriterien entsprechen.
+    today: heute
+    validation_errors:
+      one: Etwas ist noch nicht ganz richtig! Bitte korrigiere den Fehler
+      other: Etwas ist noch nicht ganz richtig! Bitte korrigiere %{count} Fehler
+  imports:
+    errors:
+      empty: Leere CSV-Datei
+      incompatible_type: Inkompatibel mit dem ausgewählten Importtyp
+      invalid_csv_file: 'Ungültige CSV-Datei. Fehler: %{error}'
+      over_rows_processing_limit: enthält mehr als %{count} Zeilen
+      too_large: Datei ist zu groß
+    failures: Fehler
+    imported: Importiert
+    mismatched_types_warning: Möglicherweise hast du den falschen Typ für diesen Import ausgewählt. Bitte überprüfe alles noch einmal.
+    modes:
+      merge: Zusammenführen
+      merge_long: Bestehende Datensätze beibehalten und neue hinzufügen
+      overwrite: Überschreiben
+      overwrite_long: Bestehende Datensätze durch neue ersetzen
+    overwrite_preambles:
+      blocking_html:
+        one: Du bist dabei, <strong>deine Liste blockierter Konten</strong> aus <strong>%{filename}</strong> durch bis zu <strong>%{count} Konto</strong> zu ersetzen.
+        other: Du bist dabei, <strong>deine Liste blockierter Konten</strong> aus <strong>%{filename}</strong> durch bis zu <strong>%{count} Konten</strong> zu ersetzen.
+      bookmarks_html:
+        one: Du bist dabei, <strong>deine Lesezeichen</strong> aus <strong>%{filename}</strong> durch bis zu <strong>%{count} Beitrag</strong> zu ersetzen.
+        other: Du bist dabei, <strong>deine Lesezeichen</strong> aus <strong>%{filename}</strong> durch bis zu <strong>%{count} Beiträge</strong> zu ersetzen.
+      domain_blocking_html:
+        one: Du bist dabei, <strong>deine Liste blockierter Domains</strong> aus <strong>%{filename}</strong> durch bis zu <strong>%{count} Domain</strong> zu ersetzen.
+        other: Du bist dabei, <strong>deine Liste blockierter Domains</strong> aus <strong>%{filename}</strong> durch bis zu <strong>%{count} Domains</strong> zu ersetzen.
+      following_html:
+        one: Du bist dabei, bis zu <strong>%{count} Konto</strong> aus <strong>%{filename}</strong> zu <strong>folgen</strong> und <strong>allen anderen zu entfolgen</strong>.
+        other: Du bist dabei, bis zu <strong>%{count} Konten</strong> aus <strong>%{filename}</strong> zu <strong>folgen</strong> und <strong>allen anderen zu entfolgen</strong>.
+      lists_html:
+        one: Du bist dabei, <strong>deine Listen</strong> mit dem Inhalt aus <strong>%{filename}</strong> zu <strong>ersetzen</strong>. Bis zu <strong>%{count} Konto</strong> wird zu neuen Listen hinzugefügt.
+        other: Du bist dabei, <strong>deine Listen</strong> mit dem Inhalt aus <strong>%{filename}</strong> zu <strong>ersetzen</strong>. Bis zu <strong>%{count} Konten</strong> wird zu neuen Listen hinzugefügt.
+      muting_html:
+        one: Du bist dabei, <strong>deine Liste mit einem stummgeschalteten Konto</strong> aus <strong>%{filename}</strong> durch bis zu <strong>%{count} Konto</strong> zu ersetzen.
+        other: Du bist dabei, <strong>deine Liste stummgeschalteter Konten</strong> aus <strong>%{filename}</strong> durch bis zu <strong>%{count} Konten</strong> zu ersetzen.
+    preambles:
+      blocking_html:
+        one: Du bist dabei, bis zu <strong>%{count} Konto</strong> aus <strong>%{filename}</strong> zu <strong>blockieren</strong>.
+        other: Du bist dabei, bis zu <strong>%{count} Konten</strong> aus <strong>%{filename}</strong> zu <strong>blockieren</strong>.
+      bookmarks_html:
+        one: Du bist dabei, bis zu <strong>%{count} Beitrag</strong> aus <strong>%{filename}</strong> zu deinen <strong>Lesezeichen hinzuzufügen</strong>.
+        other: Du bist dabei, bis zu <strong>%{count} Beiträge</strong> aus <strong>%{filename}</strong> zu deinen <strong>Lesezeichen hinzuzufügen</strong>.
+      domain_blocking_html:
+        one: Du bist dabei, bis zu <strong>%{count} Domain</strong> aus <strong>%{filename}</strong> zu <strong>blockieren</strong>.
+        other: Du bist dabei, bis zu <strong>%{count} Domains</strong> aus <strong>%{filename}</strong> zu <strong>blockieren</strong>.
+      following_html:
+        one: Du bist dabei, bis zu <strong>%{count} Konto</strong> aus <strong>%{filename}</strong> zu <strong>folgen</strong>.
+        other: Du bist dabei, bis zu <strong>%{count} Konten</strong> aus <strong>%{filename}</strong> zu <strong>folgen</strong>.
+      lists_html:
+        one: Du bist dabei, bis zu <strong>%{count} Konto</strong> aus <strong>%{filename}</strong> zu deinen <strong>Listen hinzuzufügen</strong>. Wenn es keine Listen gibt, zu denen etwas hinzugefügt werden kann, dann werden neue Listen erstellt.
+        other: Du bist dabei, bis zu <strong>%{count} Konten</strong> aus <strong>%{filename}</strong> zu deinen <strong>Listen hinzuzufügen</strong>. Wenn es keine Listen gibt, zu denen etwas hinzugefügt werden kann, dann werden neue Listen erstellt.
+      muting_html:
+        one: Du bist dabei, bis zu <strong>%{count} Konto</strong> aus <strong>%{filename} stummzuschalten</strong>.
+        other: Du bist dabei, bis zu <strong>%{count} Konten</strong> aus <strong>%{filename} stummzuschalten</strong>.
+    preface: Daten, die du von einem Mastodon-Server exportiert hast, kannst du hierher importieren. Das betrifft beispielsweise die Listen von Profilen, denen du folgst oder die du blockiert hast.
+    recent_imports: Zuletzt importiert
+    states:
+      finished: Fertig
+      in_progress: In Bearbeitung
+      scheduled: Geplant
+      unconfirmed: Unbestätigt
+    status: Status
+    success: Deine Daten wurden erfolgreich hochgeladen und werden in Kürze verarbeitet
+    time_started: Gestartet am
+    titles:
+      blocking: Blockierte Konten importieren
+      bookmarks: Lesezeichen importieren
+      domain_blocking: Blockierte Domains importieren
+      following: Gefolgte Konten importieren
+      lists: Listen importieren
+      muting: Stummgeschaltete Konten importieren
+    type: Importtyp
+    type_groups:
+      constructive: Folge ich & Lesezeichen
+      destructive: Blockierte & Stummgeschaltete
+    types:
+      blocking: Blockierte Profile
+      bookmarks: Lesezeichen
+      domain_blocking: Blockierte Domains
+      following: Folge ich
+      lists: Listen
+      muting: Stummgeschaltete Profile
+    upload: Datei importieren
+  invites:
+    delete: Deaktivieren
+    expired: Abgelaufen
+    expires_in:
+      '1800': 30 Minuten
+      '21600': 6 Stunden
+      '3600': 1 Stunde
+      '43200': 12 Stunden
+      '604800': 1 Woche
+      '86400': 1 Tag
+    expires_in_prompt: Nie
+    generate: Einladungslink erstellen
+    invalid: Diese Einladung ist ungültig
+    invited_by: 'Du wurdest eingeladen von:'
+    max_uses:
+      one: Eine Verwendung
+      other: "%{count} Verwendungen"
+    max_uses_prompt: Unbegrenzt
+    prompt: Erstelle Einladungen und teile die dazugehörigen Links, um anderen einen Zugang zu diesem Server zu gewähren
+    table:
+      expires_at: Läuft ab
+      uses: Verwendungen
+    title: Einladungen
+  lists:
+    errors:
+      limit: Du hast die maximale Anzahl an Listen erreicht
+  login_activities:
+    authentication_methods:
+      otp: Zwei-Faktor-Authentisierungs-App
+      password: Passwort
+      sign_in_token: E-Mail-Sicherheitscode
+      webauthn: Sicherheitsschlüssel
+    description_html: Wenn du verdächtige Aktivitäten bemerkst, die du nicht verstehst oder zuordnen kannst, solltest du dringend dein Passwort ändern und ungeachtet dessen die Zwei-Faktor-Authentisierung aktivieren.
+    empty: Kein Anmeldeverlauf verfügbar
+    failed_sign_in_html: Fehlgeschlagener Anmeldeversuch mit %{method} von %{ip} (%{browser})
+    successful_sign_in_html: Erfolgreiches Anmelden mit %{method} von %{ip} (%{browser})
+    title: Anmeldeverlauf
+  mail_subscriptions:
+    unsubscribe:
+      action: Ja, abbestellen
+      complete: Abbestellt
+      confirmation_html: Möchtest du %{type} für Mastodon auf %{domain} an deine E-Mail-Adresse %{email} wirklich abbestellen? Du kannst dies später in den Einstellungen <a href="%{settings_path}">Benachrichtigungen per E-Mail</a> rückgängig machen.
+      emails:
+        notification_emails:
+          favourite: E-Mail-Benachrichtigungen bei Favoriten
+          follow: E-Mail-Benachrichtigungen bei Followern
+          follow_request: E-Mail-Benachrichtigungen bei Follower-Anfragen
+          mention: E-Mail-Benachrichtigungen bei Erwähnungen
+          reblog: E-Mail-Benachrichtigungen bei geteilten Beiträgen
+      resubscribe_html: Falls du etwas irrtümlich abbestellt hast, kannst du das in den Einstellungen <a href="%{settings_path}">Benachrichtigungen per E-Mail</a> rückgängig machen.
+      success_html: Du wirst nicht länger %{type} für Mastodon auf %{domain} an deine E-Mail-Adresse %{email} erhalten.
+      title: Abbestellen
+  media_attachments:
+    validations:
+      images_and_video: Es kann kein Video an einen Beitrag angehängt werden, der bereits Bilder enthält
+      not_found: Medieninhalt(e) %{ids} nicht gefunden oder bereits an einen anderen Beitrag angehängt
+      not_ready: Dateien, die noch nicht verarbeitet wurden, können nicht angehängt werden. Versuche es gleich noch einmal!
+      too_many: Mehr als vier Dateien können nicht angehängt werden
+  migrations:
+    acct: umgezogen nach
+    cancel: Nicht mehr weiterleiten
+    cancel_explanation: Das Abbrechen der Weiterleitung wird dein aktuelles Konto erneut aktivieren, aber keine Follower zurückholen, die auf dieses Konto verschoben wurden.
+    cancelled_msg: Die Weiterleitung wurde erfolgreich beendet.
+    errors:
+      already_moved: ist das gleiche Konto, zu dem du bereits umgezogen bist
+      missing_also_known_as: ist kein Alias für dieses Konto
+      move_to_self: darf nicht das aktuelles Konto sein
+      not_found: konnte nicht gefunden werden
+      on_cooldown: Die Abklingzeit läuft gerade
+    followers_count: Anzahl der Follower zum Zeitpunkt des Umzugs
+    incoming_migrations: Von einem anderen Konto umziehen
+    incoming_migrations_html: Um von einem anderen Konto zu diesem umzuziehen, musst du zuerst ein <a href="%{path}">Konto-Alias erstellen</a>.
+    moved_msg: Dein Konto wird jetzt auf %{acct} weitergeleitet und deine Follower werden übertragen.
+    not_redirecting: Dein Konto wird derzeit nicht auf ein anderes Konto weitergeleitet.
+    on_cooldown: Du bist mit deinem Konto erst vor Kurzem umgezogen. Diese Funktion wird in %{count} Tagen wieder verfügbar sein.
+    past_migrations: Vorherige Umzüge
+    proceed_with_move: Follower übertragen
+    redirected_msg: Dein Konto wird nun zu %{acct} weitergeleitet.
+    redirecting_to: Dein Konto wird zu %{acct} weitergeleitet.
+    set_redirect: Weiterleitung einrichten
+    warning:
+      backreference_required: Das neue Konto muss zuerst auf das alte Konto verweisen
+      before: 'Bevor du fortfährst, lies bitte diese Hinweise sorgfältig durch:'
+      cooldown: Nach dem Umzug wird es eine Weile dauern, bis du erneut umziehen darfst
+      disabled_account: Dein altes Konto ist nur noch eingeschränkt verwendbar. Du kannst jedoch deine Daten exportieren und das Konto wieder reaktivieren.
+      followers: Alle Follower werden vom alten zum neuen Konto übertragen
+      only_redirect_html: Alternativ kannst du auch <a href="%{path}">nur eine Weiterleitung zu deinem neuen Konto</a> einrichten, ohne die Follower zu übertragen.
+      other_data: Keine anderen Daten werden automatisch zum neuen Konto übertragen
+      redirect: Dein altes Konto wird einen Hinweis erhalten, dass du umgezogen bist. Außerdem wird das Profil von Suchanfragen ausgeschlossen
+  moderation:
+    title: Moderation
+  move_handler:
+    carry_blocks_over_text: Dieses Konto ist von %{acct}, das du blockiert hast, umgezogen.
+    carry_mutes_over_text: Dieses Konto ist von %{acct}, das du stummgeschaltet hast, umgezogen.
+    copy_account_note_text: 'Dieses Konto ist von %{acct} umgezogen. Hier deine damals verfassten Notizen zum Profil:'
+  navigation:
+    toggle_menu: Menü ein-/ausblenden
+  notification_mailer:
+    admin:
+      report:
+        subject: "%{name} hat eine Meldung eingereicht"
+      sign_up:
+        subject: "%{name} registrierte sich"
+    favourite:
+      body: 'Dein Beitrag wurde von %{name} favorisiert:'
+      subject: "%{name} favorisierte deinen Beitrag"
+      title: Neue Favorisierung
+    follow:
+      body: "%{name} folgt dir jetzt!"
+      subject: "%{name} folgt dir jetzt"
+      title: Neuer Follower
+    follow_request:
+      action: Follower-Anfragen verwalten
+      body: "%{name} möchte dir folgen"
+      subject: 'Ausstehende Follower-Anfragen: %{name}'
+      title: Neue Follower-Anfrage
+    mention:
+      action: Antworten
+      body: 'Du wurdest von %{name} erwähnt:'
+      subject: "%{name} erwähnte dich"
+      title: Neue Erwähnung
+    poll:
+      subject: Eine Umfrage von %{name} ist beendet
+    quote:
+      body: 'Dein Beitrag wurde von %{name} zitiert:'
+      subject: "%{name} zitierte deinen Beitrag"
+      title: Neuer zitierter Beitrag
+    reblog:
+      body: 'Dein Beitrag wurde von %{name} geteilt:'
+      subject: "%{name} teilte deinen Beitrag"
+      title: Dein Beitrag wurde geteilt
+    status:
+      subject: "%{name} veröffentlichte gerade einen Beitrag"
+    update:
+      subject: "%{name} bearbeitete einen Beitrag"
+  notifications:
+    administration_emails: Admin-E-Mail-Benachrichtigungen
+    email_events: Benachrichtigungen per E-Mail
+    email_events_hint: 'Bitte die Ereignisse auswählen, für die du Benachrichtigungen per E-Mail erhalten möchtest:'
+  number:
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Mrd.
+          million: Mio.
+          quadrillion: Brd.
+          thousand: Tsd.
+          trillion: Bio.
+  otp_authentication:
+    code_hint: Gib den Code ein, den deine 2FA- bzw. TOTP-App generiert hat, um den Vorgang zu bestätigen
+    description_html: Wenn du die <strong>Zwei-Faktor-Authentisierung</strong> (2FA) mit einer Authentifizierungs-App deines Smartphones aktivierst, benötigst du neben dem regulären Passwort zusätzlich auch den zeitbasierten Code der 2FA-App, um dich anmelden zu können.
+    enable: Aktivieren
+    instructions_html: "<strong>Scanne diesen QR-Code mit einer beliebigen Authentisierungs-App (TOTP)</strong>. Diese App generiert dann zeitbasierte Codes, die du beim Anmelden zusätzlich zum regulären Passwort eingeben musst."
+    manual_instructions: Wenn du den QR-Code nicht einscannen kannst, sondern die Zahlenfolge manuell eingeben musst, ist hier der geheime Token für deine 2FA-App.
+    setup: Einrichten
+    wrong_code: Der eingegebene Code ist ungültig! Laufen Serverzeit und Gerätezeit synchron?
+  pagination:
+    newer: Neuer
+    next: Weiter
+    older: Älter
+    prev: Zurück
+    truncate: "&hellip;"
+  polls:
+    errors:
+      already_voted: An dieser Umfrage hast du bereits teilgenommen
+      duplicate_options: enthält doppelte Einträge
+      duration_too_long: liegt zu weit in der Zukunft
+      duration_too_short: ist zu früh
+      expired: Diese Umfrage ist bereits beendet
+      invalid_choice: Diese Auswahl existiert nicht
+      over_character_limit: darf nicht länger als %{max} Zeichen sein
+      self_vote: Du kannst an deinen eigenen Umfragen nicht selbst teilnehmen
+      too_few_options: muss mehr als ein Auswahlfeld enthalten
+      too_many_options: darf nicht mehr als %{max} Auswahlfelder enthalten
+    vote: Abstimmen
+  posting_defaults:
+    explanation: Diese Einstellungen werden standardmäßig für neue Beiträge verwendet. Du kannst sie auch beim Verfassen eines Beitrags individuell anpassen.
+  preferences:
+    other: Erweitert
+    posting_defaults: Standardeinstellungen für Beiträge
+    public_timelines: Öffentliche Timelines
+  privacy:
+    hint_html: "<strong>Bestimme selbst, wie dein Profil und deine Beiträge gefunden werden sollen.</strong> Zahlreiche Mastodon-Funktionen können dir für eine größere Reichweite behilflich sein. Nimm dir einen Moment Zeit, um diese Einstellungen zu überprüfen."
+    privacy: Datenschutz
+    privacy_hint_html: Bestimme, wie viele Informationen du für andere preisgeben möchtest. Viele Menschen entdecken interessante Profile und coole Apps, indem sie die Follower anderer Profile durchstöbern und die Apps sehen, über die Beiträge veröffentlicht wurden – möglicherweise möchtest du diese Informationen ausblenden.
+    reach: Reichweite
+    reach_hint_html: Bestimme, ob Profile dich entdecken und dir folgen dürfen. Möchtest du, dass deine Beiträge unter „Entdecken“ erscheinen? Möchtest du, dass andere dich in ihren Follower-Empfehlungen sehen? Möchtest du alle neuen Follower automatisch akzeptieren oder jeden einzelnen genehmigen?
+    search: Suche
+    search_hint_html: Bestimme, wie du entdeckt werden möchtest. Möchtest du, dass die Leute dich anhand deiner öffentlichen Beiträge finden können? Möchtest du, dass Menschen außerhalb von Mastodon dein Profil finden, wenn sie im Internet suchen? Bitte beachte, dass ein vollständiger Ausschluss aus allen Suchmaschinen für öffentlich zugängliche Informationen nicht garantiert werden kann.
+    title: Datenschutz und Reichweite
+  privacy_policy:
+    title: Datenschutzerklärung
+  reactions:
+    errors:
+      limit_reached: Limit für verschiedene Reaktionen erreicht
+      unrecognized_emoji: ist ein unbekanntes Emoji
+  redirects:
+    prompt: Wenn du diesem Link vertraust, dann klicke ihn an, um fortzufahren.
+    title: Du verlässt %{instance}.
+  relationships:
+    activity: Kontoaktivität
+    confirm_follow_selected_followers: Möchtest du den ausgewählten Followern folgen?
+    confirm_remove_selected_followers: Möchtest du die ausgewählten Follower wirklich entfernen?
+    confirm_remove_selected_follows: Möchtest du den ausgewählten Konten wirklich entfolgen?
+    dormant: Inaktiv
+    follow_failure: Einigen der ausgewählten Konten konnte nicht gefolgt werden.
+    follow_selected_followers: Ausgewählten Followern folgen
+    followers: Follower
+    following: Folge ich
+    invited: Eingeladen
+    last_active: Zuletzt aktiv
+    most_recent: Neueste
+    moved: Umgezogen
+    mutual: Gegenseitig
+    primary: Primär
+    relationship: Beziehung
+    remove_selected_domains: Alle Follower von den ausgewählten Domains entfernen
+    remove_selected_followers: Ausgewählten Followern entfolgen
+    remove_selected_follows: Ausgewählten Profilen entfolgen
+    status: Kontostatus
+  remote_follow:
+    missing_resource: Die erforderliche Weiterleitungs-URL für dein Konto konnte nicht gefunden werden
+  reports:
+    errors:
+      invalid_rules: verweist nicht auf gültige Serverregeln
+  rss:
+    content_warning: 'Inhaltswarnung:'
+    descriptions:
+      account: Öffentliche Beiträge von @%{acct}
+      tag: 'Öffentliche Beiträge mit dem Hashtag #%{hashtag}'
+  scheduled_statuses:
+    over_daily_limit: Du hast das Limit von %{limit} geplanten Beiträgen für heute erreicht
+    over_total_limit: Du hast das Limit für geplante Beiträge, das %{limit} beträgt, erreicht
+    too_soon: Datum muss in der Zukunft liegen
+  self_destruct:
+    lead_html: Bedauerlicherweise wird <strong>%{domain}</strong> den Betrieb für immer einstellen. Wenn du dort ein Konto angelegt hast, wirst du es nicht weiter verwenden können. Du kannst allerdings eine Sicherung deiner Daten anfordern.
+    title: Dieser Server wird den Betrieb einstellen
+  sessions:
+    activity: Letzte Aktivität
+    browser: Browser
+    browsers:
+      alipay: Alipay
+      blackberry: BlackBerry
+      chrome: Chrome
+      edge: Edge
+      electron: Electron
+      firefox: Firefox
+      generic: Unbekannter Browser
+      huawei_browser: Huawei Browser
+      ie: Internet Explorer
+      micro_messenger: MicroMessenger
+      nokia: Nokia S40 Ovi Browser
+      opera: Opera
+      otter: Otter
+      phantom_js: PhantomJS
+      qq: QQ Browser
+      safari: Safari
+      uc_browser: UC Browser
+      unknown_browser: Unbekannter Browser
+      weibo: Weibo
+    current_session: Aktuelle Sitzung
+    date: Datum
+    description: "%{browser} auf %{platform}"
+    explanation: Dies sind die Webbrowser, die derzeit mit deinem Mastodon-Konto verbunden sind.
+    ip: IP-Adresse
+    platforms:
+      adobe_air: Adobe Air
+      android: Android
+      blackberry: BlackBerry
+      chrome_os: ChromeOS
+      firefox_os: Firefox OS
+      ios: iOS
+      kai_os: KaiOS
+      linux: Linux
+      mac: macOS
+      unknown_platform: Unbekannte Plattform
+      windows: Windows
+      windows_mobile: Windows Mobile
+      windows_phone: Windows Phone
+    revoke: Widerrufen
+    revoke_success: Sitzung erfolgreich widerrufen
+    title: Sitzungen
+    view_authentication_history: Anmeldeverlauf deines Kontos anzeigen
+  settings:
+    account: Konto
+    account_settings: Kontoeinstellungen
+    aliases: Konto-Aliasse
+    appearance: Design
+    authorized_apps: Autorisierte Anwendungen
+    back: Zurück zu Mastodon
+    delete: Kontolöschung
+    development: Entwicklung
+    edit_profile: Profil bearbeiten
+    export: Exportieren
+    featured_tags: Vorgestellte Hashtags
+    import: Importieren
+    import_and_export: Importieren und exportieren
+    migrate: Kontoumzug
+    notifications: E-Mail-Benachrichtigungen
+    preferences: Einstellungen
+    profile: Öffentliches Profil
+    relationships: Follower und Folge ich
+    severed_relationships: Getrennte Beziehungen
+    statuses_cleanup: Automatische Löschung
+    strikes: Maßnahmen
+    two_factor_authentication: Zwei-Faktor-Authentisierung
+    webauthn_authentication: Sicherheitsschlüssel
+  severed_relationships:
+    download: Herunterladen (%{count})
+    event_type:
+      account_suspension: Kontosperre (%{target_name})
+      domain_block: Serversperre (%{target_name})
+      user_domain_block: Du hast %{target_name} blockiert
+    lost_followers: Verlorene Follower
+    lost_follows: Konten entfolgt
+    preamble: Möglicherweise verlierst du Follower und entfolgst Konten, wenn du eine Domain blockierst oder Moderator*innen externe Server sperren. Sollte das der Fall sein, wirst du eine Liste mit den getrennten Beziehungen herunterladen können. Dadurch kannst du die Änderungen einsehen oder die Liste auf einen anderen Server importieren.
+    purged: Informationen über diesen Server wurden von deinen Server-Administrator*innen entfernt.
+    type: Ereignis
+  statuses:
+    attached:
+      audio:
+        one: "%{count} Audiodatei"
+        other: "%{count} Audiodateien"
+      description: 'Angehängt: %{attached}'
+      image:
+        one: "%{count} Bild"
+        other: "%{count} Bilder"
+      video:
+        one: "%{count} Video"
+        other: "%{count} Videos"
+    boosted_from_html: Geteilt von %{acct_link}
+    content_warning: 'Inhaltswarnung: %{warning}'
+    default_language: Wie die Sprache des Webinterface
+    disallowed_hashtags:
+      one: 'enthält einen nicht-erlaubten Hashtag: %{tags}'
+      other: 'enthält nicht-erlaubte Hashtags: %{tags}'
+    edited_at_html: 'Bearbeitet: %{date}'
+    errors:
+      in_reply_not_found: Der Beitrag, auf den du antworten möchtest, scheint nicht zu existieren.
+      quoted_status_not_found: Der Beitrag, den du zitieren möchtest, scheint nicht zu existieren.
+    over_character_limit: Begrenzung von %{max} Zeichen überschritten
+    pin_errors:
+      direct: Beiträge, die nur für erwähnte Profile sichtbar sind, können nicht angeheftet werden
+      limit: Du hast bereits die maximale Anzahl an Beiträgen angeheftet
+      ownership: Du kannst nur eigene Beiträge anheften
+      reblog: Du kannst keine geteilten Beiträge anheften
+    quote_policies:
+      followers: Nur Follower
+      nobody: Nur von mir
+      public: Alle
+    title: "%{name}: „%{quote}“"
+    visibilities:
+      direct: Private Erwähnung
+      private: Nur Follower
+      private_long: Nur für deine Follower sichtbar
+      public: Öffentlich
+      public_long: Alle innerhalb und außerhalb von Mastodon
+      unlisted: Nicht gelistet
+      unlisted_long: Wird nicht in den Suchergebnissen, Trends oder öffentlichen Timelines von Mastodon angezeigt
+  statuses_cleanup:
+    enabled: Alte Beiträge automatisch entfernen
+    enabled_hint: Löscht automatisch deine Beiträge, sobald sie die angegebene Altersgrenze erreicht haben, es sei denn, sie entsprechen einer der unten angegebenen Ausnahmen
+    exceptions: Ausnahmen
+    explanation: Damit der Server nicht durch das Löschen von Beiträgen ausgebremst wird, wartet die Mastodon-Software, bis wenig(er) los ist. Deshalb könnten deine Beiträge ggf. erst einige Zeit nach Erreichen der Altersgrenze gelöscht werden.
+    ignore_favs: Favoriten ignorieren
+    ignore_reblogs: Geteilte Beiträge ignorieren
+    interaction_exceptions: Ausnahmen basierend auf Interaktionen
+    interaction_exceptions_explanation: Beachte, dass Beiträge nicht gelöscht werden, sobald deine Grenzwerte für Favoriten oder geteilte Beiträge einmal überschritten wurden – auch dann nicht, wenn diese Schwellenwerte mittlerweile nicht mehr erreicht werden.
+    keep_direct: Private Nachrichten behalten
+    keep_direct_hint: Löscht keinen deiner Beiträge, die nur für erwähnte Profile sichtbar sind
+    keep_media: Beiträge mit Medien behalten
+    keep_media_hint: Löscht keinen deiner Beiträge mit Medienanhängen
+    keep_pinned: Angeheftete Beiträge behalten
+    keep_pinned_hint: Löscht keinen deiner angehefteten Beiträge
+    keep_polls: Umfragen behalten
+    keep_polls_hint: Löscht keine deiner Umfragen
+    keep_self_bookmark: Als Lesezeichen markierte Beiträge behalten
+    keep_self_bookmark_hint: Löscht keinen deiner Beiträge, die du als Lesezeichen gesetzt hast
+    keep_self_fav: Favorisierte Beiträge behalten
+    keep_self_fav_hint: Löscht keinen deiner eigenen Beiträge, die du favorisiert hast
+    min_age:
+      '1209600': 2 Wochen
+      '15778476': 6 Monate
+      '2629746': 1 Monat
+      '31556952': 1 Jahr
+      '5259492': 2 Monate
+      '604800': 1 Woche
+      '63113904': 2 Jahre
+      '7889238': 3 Monate
+    min_age_label: Altersgrenze
+    min_favs: Behalte Beiträge, die häufiger favorisiert wurden als …
+    min_favs_hint: Löscht keine Beiträge, die mindestens so oft favorisiert worden sind. Lass das Feld leer, um alle Beiträge – unabhängig der Anzahl an Favoriten – zu löschen
+    min_reblogs: Behalte Beiträge, die häufiger geteilt wurden als …
+    min_reblogs_hint: Löscht keine Beiträge, die mindestens so oft geteilt worden sind. Lass das Feld leer, um alle Beiträge – unabhängig der Anzahl an geteilten Beiträgen – zu löschen
+  stream_entries:
+    sensitive_content: Inhaltswarnung
+  strikes:
+    errors:
+      too_late: Es ist zu spät, um gegen diese Maßnahme Einspruch zu erheben
+  tags:
+    does_not_match_previous_name: entspricht nicht dem vorherigen Namen
+  terms_of_service:
+    title: Nutzungsbedingungen
+  terms_of_service_interstitial:
+    future_preamble_html: Wir aktualisieren unsere Nutzungsbedingungen, die am <strong>%{date}</strong> in Kraft treten. Bitte lies dir die aktualisierten Bedingungen sorgfältig durch.
+    past_preamble_html: Wir haben unsere Nutzungsbedingungen seit deinem letzten Besuch geändert. Bitte lies dir die aktualisierten Bedingungen sorgfältig durch.
+    review_link: Nutzungsbedingungen lesen
+    title: Die Nutzungsbedingungen von %{domain} ändern sich
+  themes:
+    contrast: Mastodon (Hoher Kontrast)
+    default: Mastodon (Dunkel)
+    mastodon-light: Mastodon (Hell)
+    system: Automatisch (wie Betriebssystem)
+  time:
+    formats:
+      default: "%d. %b %Y, %H:%M Uhr"
+      month: "%b %Y"
+      time: "%H:%M Uhr"
+      with_time_zone: "%d. %b %Y, %H:%M Uhr %Z"
+  translation:
+    errors:
+      quota_exceeded: Das Kontingent, das dem Server zur Verfügung steht, wurde für den Übersetzungsdienst überschritten.
+      too_many_requests: Der Übersetzungsdienst hat kürzlich zu viele Anfragen erhalten.
+  two_factor_authentication:
+    add: Hinzufügen
+    disable: Zwei-Faktor-Authentisierung deaktivieren
+    disabled_success: Zwei-Faktor-Authentisierung erfolgreich deaktiviert
+    edit: Bearbeiten
+    enabled: Zwei-Faktor-Authentisierung (2FA) ist aktiviert
+    enabled_success: Zwei-Faktor-Authentisierung (2FA) erfolgreich aktiviert
+    generate_recovery_codes: Wiederherstellungscodes erstellen
+    lost_recovery_codes: Wiederherstellungscodes ermöglichen es dir, wieder Zugang zu deinem Konto zu erlangen, falls du keinen Zugriff mehr auf die Zwei-Faktor-Authentisierung oder den Sicherheitsschlüssel hast. Solltest du diese Wiederherstellungscodes verloren haben, kannst du sie hier neu generieren. Deine alten, bereits erstellten Wiederherstellungscodes werden dadurch ungültig.
+    methods: Methoden der Zwei-Faktor-Authentisierung
+    otp: Authentisierungs-App
+    recovery_codes: Wiederherstellungscodes sichern
+    recovery_codes_regenerated: Wiederherstellungscodes erfolgreich neu erstellt
+    recovery_instructions_html: Falls du jemals den Zugang zu deinem Smartphone verlierst, kannst du einen der unten aufgeführten Wiederherstellungscodes verwenden, um wieder Zugang zu deinem Konto zu erhalten. <strong>Bewahre die Wiederherstellungscodes sicher auf</strong>. Du kannst sie zum Beispiel ausdrucken und zusammen mit anderen wichtigen Dokumenten aufbewahren.
+    webauthn: Sicherheitsschlüssel
+  user_mailer:
+    announcement_published:
+      description: 'Ankündigung der Administrator*innen von %{domain}:'
+      subject: Ankündigung
+      title: Ankündigung von %{domain}
+    appeal_approved:
+      action: Kontoeinstellungen
+      explanation: Der Einspruch gegen deinen Verstoß vom %{strike_date}, den du am %{appeal_date} eingereicht hast, wurde genehmigt. Dein Konto ist wieder in Ordnung.
+      subject: Dein Einspruch vom %{date} wurde angenommen
+      subtitle: Dein Konto ist wieder in Ordnung.
+      title: Einspruch angenommen
+    appeal_rejected:
+      explanation: Der Einspruch gegen deinen Verstoß vom %{strike_date}, den du am %{appeal_date} eingereicht hast, wurde abgelehnt.
+      subject: Dein Einspruch vom %{date} wurde abgelehnt
+      subtitle: Dein Einspruch wurde abgelehnt.
+      title: Einspruch abgelehnt
+    backup_ready:
+      explanation: Du hast eine vollständige Datensicherung deines Mastodon-Kontos angefordert.
+      extra: Sie ist jetzt zum Herunterladen bereit!
+      subject: Dein persönliches Archiv kann heruntergeladen werden
+      title: Archiv-Download
+    failed_2fa:
+      details: 'Details zum Anmeldeversuch:'
+      explanation: Jemand hat versucht, sich bei deinem Konto anzumelden, aber die Zwei-Faktor-Authentisierung schlug fehl.
+      further_actions_html: Solltest du das nicht gewesen sein, empfehlen wir dir, sofort %{action}, da dein Konto möglicherweise kompromittiert ist.
+      subject: Zwei-Faktor-Authentisierung fehlgeschlagen
+      title: Zwei-Faktor-Authentisierung fehlgeschlagen
+    suspicious_sign_in:
+      change_password: dein Passwort zu ändern
+      details: 'Hier sind die Details zu den Anmeldeversuchen:'
+      explanation: Wir haben eine Anmeldung zu deinem Konto von einer neuen IP-Adresse festgestellt.
+      further_actions_html: Wenn du das nicht warst, empfehlen wir dir schnellstmöglich, %{action} und die Zwei-Faktor-Authentisierung für dein Konto zu aktivieren, um es abzusichern.
+      subject: Es wurde auf dein Konto von einer neuen IP-Adresse zugegriffen
+      title: Eine neue Anmeldung
+    terms_of_service_changed:
+      agreement: Du stimmst den neuen Nutzungsbedingungen automatisch zu, wenn du %{domain} weiterhin verwendest. Falls du mit diesen nicht einverstanden bist, kannst du die Vereinbarung mit %{domain} jederzeit widerrufen, indem du dein Konto dort löschst.
+      changelog: 'Die Änderungen im Überblick:'
+      description: 'Du erhältst diese E-Mail, weil wir für %{domain} einige Änderungen an unseren Nutzungsbedingungen vorgenommen haben. Diese Änderungen gelten ab %{date}. Wir empfehlen, die vollständig aktualisierte Fassung hier zu lesen:'
+      description_html: Du erhältst diese E-Mail, weil wir für %{domain} einige Änderungen an unseren Nutzungsbedingungen vorgenommen haben. Diese Änderungen gelten ab <strong>%{date}</strong>. Wir empfehlen, die <a href="%{path}" target="_blank">vollständig aktualisierte Fassung hier zu lesen</a>.
+      sign_off: Das Team von %{domain}
+      subject: Aktualisierung unserer Nutzungsbedingungen
+      subtitle: Die Nutzungsbedingungen von %{domain} ändern sich
+      title: Wichtige Mitteilung
+    warning:
+      appeal: Einspruch erheben
+      appeal_description: Wenn du glaubst, dass es sich um einen Fehler handelt, kannst du einen Einspruch an die Administration von %{instance} senden.
+      categories:
+        spam: Spam
+        violation: Inhalt verstößt gegen die folgenden Serverregeln
+      explanation:
+        delete_statuses: Einige deiner Beiträge haben gegen eine oder mehrere Serverregeln verstoßen und wurden daher von den Moderator*innen von %{instance} entfernt.
+        disable: Du kannst dein Konto nicht mehr verwenden, aber dein Profil und deine anderen Daten bleiben erhalten. Du kannst eine Sicherung deiner Daten anfordern, die Kontoeinstellungen ändern oder dein Konto löschen.
+        mark_statuses_as_sensitive: Ein oder mehrere deiner Beiträge wurden von den Moderator*innen von %{instance} mit einer Inhaltswarnung versehen. Das bedeutet, dass die Medien in den Beiträgen erst angeklickt werden müssen, bevor sie angezeigt werden. Beim Verfassen der nächsten Beiträge kannst du auch selbst eine Inhaltswarnung für hochgeladene Medien festlegen.
+        sensitive: Von nun an werden alle deine hochgeladenen Mediendateien mit einer Inhaltswarnung versehen und hinter einer Warnung versteckt.
+        silence: Du kannst dein Konto weiterhin verwenden, aber nur Personen, die dir bereits folgen, sehen deine Beiträge auf diesem Server. Ebenso kannst du aus verschiedenen Suchfunktionen ausgeschlossen werden. Andere können dir jedoch weiterhin manuell folgen.
+        suspend: Du kannst dein Konto nicht mehr verwenden und dein Profil und andere Daten sind nicht mehr verfügbar. Du kannst dich immer noch anmelden, um eine Sicherung deiner Daten anzufordern, bis die Daten innerhalb von 30 Tagen vollständig gelöscht wurden. Allerdings werden wir einige Daten speichern, um zu verhindern, dass du die Sperrung umgehst.
+      reason: 'Begründung:'
+      statuses: 'Betroffene Beiträge:'
+      subject:
+        delete_statuses: Deine Beiträge von %{acct} sind entfernt worden
+        disable: Dein Konto %{acct} wurde eingefroren
+        mark_statuses_as_sensitive: Deine Beiträge von %{acct} wurden mit einer Inhaltswarnung versehen
+        none: Warnung für %{acct}
+        sensitive: Deine Beiträge von %{acct} werden künftig mit einer Inhaltswarnung versehen
+        silence: Dein Konto %{acct} wurde eingeschränkt
+        suspend: Dein Konto %{acct} wurde gesperrt
+      title:
+        delete_statuses: Beiträge entfernt
+        disable: Konto eingefroren
+        mark_statuses_as_sensitive: Mit einer Inhaltswarnung versehene Beiträge
+        none: Warnung
+        sensitive: Konto mit einer Inhaltswarnung versehen
+        silence: Konto stummgeschaltet
+        suspend: Konto gesperrt
+    welcome:
+      apps_android_action: Aus dem Google Play Store herunterladen
+      apps_ios_action: Im App Store herunterladen
+      apps_step: Lade unsere offiziellen Apps herunter.
+      apps_title: Mastodon-Apps
+      checklist_subtitle: 'Fangen wir an, diese neue soziale Dimension zu erkunden:'
+      checklist_title: Willkommensleitfaden
+      edit_profile_action: Personalisieren
+      edit_profile_step: Mit einem vollständigen Profil interagieren andere eher mit dir.
+      edit_profile_title: Personalisiere dein Profil
+      explanation: Hier sind ein paar Tipps, um loszulegen
+      feature_action: Mehr erfahren
+      feature_audience: Mastodon bietet dir eine einzigartige Möglichkeit, deine Reichweite ohne Mittelsperson zu verwalten. Auf deiner eigenen Infrastruktur bereitgestellt, ermöglicht Mastodon es dir, jedem anderen Mastodon-Server zu folgen und von jedem anderen Server aus gefolgt zu werden. Ebenso steht Mastodon unter deiner Kontrolle.
+      feature_audience_title: Baue deine Reichweite mit Vertrauen auf
+      feature_control: Du weißt am besten, was du auf deiner Startseite sehen möchtest. Keine Algorithmen oder Werbung, die deine Zeit verschwenden. Folge Nutzer*innen auf allen Mastodon-Servern von einem einzelnen Konto aus und empfange deren Beiträge in chronologischer Reihenfolge. Mache Mastodon zu deinem ganz persönlichen Fleckchen im Internet.
+      feature_control_title: Behalte die Kontrolle über deine eigene Timeline
+      feature_creativity: Mastodon unterstützt Audio-, Video- und Bildbeiträge, Beschreibungen, Umfragen, Inhaltswarnungen, animierte Avatare, benutzerdefinierte Emojis, das Zuschneiden von Vorschaubildern und vieles mehr, um dir zu helfen, dich online zu entfalten. Egal, ob du deine Kunst, deine Musik oder deinen Podcast veröffentlichst – Mastodon ist für dich da.
+      feature_creativity_title: Einzigartige Kreativität
+      feature_moderation: Mastodon legt die Entscheidungskraft zurück in deine Hände. Jeder Server erstellt eigene Regeln und Vorschriften, die nur lokal, pro einzelnem Server durchgesetzt werden – und nicht von oben herab, wie es bei den kommerziellen sozialen Medien der Fall ist. Dadurch ist Mastodon viel anpassungsfähiger für verschiedene Gruppen von Menschen. Registriere dich bei einem Server, dessen Regeln du magst, oder hoste deinen eigenen Server.
+      feature_moderation_title: Moderation so, wie sie sein sollte
+      follow_action: Folgen
+      follow_step: Interessanten Profilen zu folgen ist das, was Mastodon ausmacht.
+      follow_title: Personalisiere deine Startseite
+      follows_subtitle: Folge bekannten Profilen
+      follows_title: Empfohlene Profile
+      follows_view_more: Weitere Profile zum Folgen entdecken
+      hashtags_recent_count:
+        one: "%{people} Profil in den vergangenen 2 Tagen"
+        other: "%{people} Profile in den vergangenen 2 Tagen"
+      hashtags_subtitle: Entdecke, was in den vergangenen 2 Tagen angesagt war
+      hashtags_title: Angesagte Hashtags
+      hashtags_view_more: Weitere angesagte Hashtags entdecken
+      post_action: Verfassen
+      post_step: Begrüße die Welt mit Text, Fotos, Videos oder Umfragen.
+      post_title: Erstelle deinen ersten Beitrag
+      share_step: Lass deine Freund*innen wissen, wie sie dich auf Mastodon finden können.
+      share_title: Teile dein Mastodon-Profil
+      sign_in_action: Anmelden
+      subject: Willkommen bei Mastodon!
+      title: Willkommen an Bord, %{name}!
+  users:
+    follow_limit_reached: Du kannst nicht mehr als %{limit} Profilen folgen
+    go_to_sso_account_settings: Kontoeinstellungen des Identitätsanbieters aufrufen
+    invalid_otp_token: Ungültiger Code der Zwei-Faktor-Authentisierung
+    otp_lost_help_html: Wenn du beides nicht mehr weißt, melde dich bitte bei uns unter der E-Mail-Adresse %{email}
+    rate_limited: Zu viele Authentisierungsversuche. Bitte versuche es später noch einmal.
+    seamless_external_login: Du bist über einen externen Dienst angemeldet, daher sind Passwort- und E-Mail-Einstellungen nicht verfügbar.
+    signed_in_as: 'Angemeldet als:'
+  verification:
+    extra_instructions_html: <strong>Hinweis:</strong> Der Link auf deiner Website kann unsichtbar sein. Der wichtige Teil ist <code>rel="me"</code>. Du kannst auch den Tag <code>link</code> im <code>head</code> (statt <code>a</code> im <code>body</code>) verwenden, jedoch muss die Internetseite ohne JavaScript abrufbar sein.
+    here_is_how: So funktioniert’s
+    hint_html: "<strong>Alle können ihre Identität auf Mastodon verifizieren.</strong> Basierend auf offenen Standards – jetzt und für immer kostenlos. Alles, was du brauchst, ist eine eigene Website. Wenn du von deinem Profil auf diese Website verlinkst, überprüfen wir, ob die Website zu deinem Profil zurückverlinkt, und zeigen einen visuellen Hinweis an."
+    instructions_html: Kopiere den unten stehenden Code und füge ihn in den HTML-Code deiner Website ein. Trage anschließend die Adresse deiner Website in ein Zusatzfeld auf deinem Profil ein und speichere die Änderungen. Die Zusatzfelder befinden sich im Reiter „Profil bearbeiten“.
+    verification: Verifizierung
+    verified_links: Deine verifizierten Domains
+    website_verification: Verifizierung einer Website
+  webauthn_credentials:
+    add: Sicherheitsschlüssel hinzufügen
+    create:
+      error: Beim Hinzufügen des Sicherheitsschlüssels ist ein Fehler aufgetreten. Bitte versuche es erneut.
+      success: Dein Sicherheitsschlüssel wurde erfolgreich hinzugefügt.
+    delete: Entfernen
+    delete_confirmation: Möchtest du diesen Sicherheitsschlüssel wirklich entfernen?
+    description_html: Wenn du die <strong>Authentisierung mit Sicherheitsschlüssel</strong> aktivierst, musst du dich mit einem deiner Sicherheitsschlüssel anmelden.
+    destroy:
+      error: Beim Entfernen des Sicherheitsschlüssels ist ein Fehler aufgetreten. Bitte versuche es erneut.
+      success: Dein Sicherheitsschlüssel wurde erfolgreich entfernt.
+    invalid_credential: Ungültiger Sicherheitsschlüssel
+    nickname_hint: Gib den Spitznamen deines neuen Sicherheitsschlüssels ein
+    not_enabled: Du hast WebAuthn noch nicht aktiviert
+    not_supported: Dieser Browser unterstützt keine Sicherheitsschlüssel
+    otp_required: Um Sicherheitsschlüssel zu verwenden, aktiviere zunächst die Zwei-Faktor-Authentisierung.
+    registered_on: Registriert am %{date}

--- a/config/locales/simple_form.dsb.yml
+++ b/config/locales/simple_form.dsb.yml
@@ -1,0 +1,397 @@
+---
+dsb:
+  simple_form:
+    hints:
+      account:
+        attribution_domains: Eine Domain pro Zeile. Dadurch können falsche Zuschreibungen unterbunden werden.
+        discoverable: Deine öffentlichen Beiträge und dein Profil können in verschiedenen Bereichen auf Mastodon vorgestellt oder empfohlen werden, ebenso kann dein Profil anderen vorgeschlagen werden.
+        display_name: Dein richtiger Name oder dein Fantasiename.
+        fields: Deine Website, Pronomen, dein Alter – alles, was du möchtest.
+        indexable: Deine öffentlichen Beiträge können in den Suchergebnissen auf Mastodon erscheinen. Profile, die bereits mit deinen Beiträgen interagiert haben, können deine Beiträge immer auffinden.
+        note: 'Du kannst andere @Profile erwähnen oder #Hashtags verwenden.'
+        show_collections: Andere können deine Follower und „Folge ich“ durchstöbern. Profile, denen du folgst, werden immer sehen können, dass du ihnen folgst.
+        unlocked: Andere können dir folgen, ohne vorher manuell genehmigt werden zu müssen. Wenn du Follower-Anfragen manuell akzeptieren oder ablehnen möchtest, dann lass diese Einstellung deaktiviert.
+      account_alias:
+        acct: Gib profilname@domain des Kontos an, von dem du umziehen möchtest
+      account_migration:
+        acct: Gib profilname@domain des Kontos an, zu dem du umziehen möchtest
+      account_warning_preset:
+        text: Du kannst die Syntax wie für Beiträge verwenden – z. B. URLs, Hashtags und Erwähnungen
+        title: "(Optional) Für Empfänger*in nicht sichtbar"
+      admin_account_action:
+        include_statuses: Die Person wird sehen, welche Inhalte dich zu dieser Maßnahme veranlasst haben
+        send_email_notification: Benutzer*in wird eine Erklärung erhalten, was mit dem Konto geschehen ist
+        text_html: (Optional) Du kannst die Syntax wie für Beiträge verwenden. Du kannst <a href="%{path}">Warnvorlagen hinzufügen</a>, um Zeit zu sparen
+        type_html: Wähle aus, wie mit <strong>%{acct}</strong> vorgegangen werden soll
+        types:
+          disable: Benutzer*in daran hindern, das Konto verwenden zu können, aber die Inhalte nicht löschen oder ausblenden.
+          none: Dem Konto eine Warnung zusenden, ohne dabei eine andere Aktion vorzunehmen.
+          sensitive: Erzwingen, dass alle Medienanhänge dieses Profils mit einer Inhaltswarnung versehen werden.
+          silence: Verhindert, dass dieses Profil öffentlich sichtbare Beiträge verfassen kann, und verbirgt alle Beiträge und Benachrichtigungen vor Personen, die diesem Profil nicht folgen. Alle Meldungen zu diesem Konto werden geschlossen.
+          suspend: Verhindert jegliche Interaktion von oder zu diesem Konto und löscht dessen Inhalt. Dies kann innerhalb von 30 Tagen rückgängig gemacht werden. Alle Meldungen zu diesem Konto werden geschlossen.
+        warning_preset_id: "(Optional) Du kannst immer noch eigenen Text an das Ende der Vorlage hinzufügen"
+      announcement:
+        all_day: Falls aktiviert, werden nur der Tag bzw. die Tage innerhalb des Zeitraums angezeigt
+        ends_at: "(Optional) Die Ankündigung wird zu diesem Zeitpunkt automatisch zurückgezogen"
+        scheduled_at: Leer lassen, um die Ankündigung sofort zu veröffentlichen
+        starts_at: "(Optional) Für den Fall, dass deine Ankündigung an einen bestimmten Zeitraum gebunden ist"
+        text: Du kannst die Syntax wie für Beiträge verwenden. Bitte berücksichtige den Platz, den die Ankündigung auf dem Bildschirm der Benutzer*innen einnehmen wird
+      appeal:
+        text: Du kannst nur einmal Einspruch gegen eine Maßnahme einlegen
+      defaults:
+        autofollow: Personen, die sich über deine Einladung registrieren, folgen automatisch deinem Profil
+        avatar: WEBP, PNG, GIF oder JPG. Höchstens %{size} groß. Wird auf %{dimensions} px verkleinert
+        bot: Signalisiert, dass dieses Konto hauptsächlich automatisierte Aktionen durchführt und möglicherweise nicht persönlich betreut wird
+        context: Orte, an denen der Filter aktiv sein soll
+        current_password: Gib aus Sicherheitsgründen bitte das Passwort des aktuellen Kontos ein
+        current_username: Um das zu bestätigen, gib den Profilnamen des aktuellen Kontos ein
+        digest: Wenn du eine längere Zeit inaktiv bist oder du während deiner Abwesenheit in einer privaten Nachricht erwähnt worden bist
+        email: Du wirst eine E-Mail zur Verifizierung dieser E-Mail-Adresse erhalten
+        header: WEBP, PNG, GIF oder JPG. Höchstens %{size} groß. Wird auf %{dimensions} px verkleinert
+        inbox_url: Kopiere die URL von der Startseite des gewünschten Relais
+        irreversible: Bereinigte Beiträge verschwinden unwiderruflich für dich, auch dann, wenn dieser Filter zu einem späteren wieder entfernt wird
+        locale: Die Sprache der Bedienoberfläche, E-Mails und Push-Benachrichtigungen
+        password: Verwende mindestens 8 Zeichen
+        phrase: Wird unabhängig von der Groß- und Kleinschreibung im Text oder der Inhaltswarnung eines Beitrags abgeglichen
+        scopes: Welche Schnittstellen der Applikation erlaubt sind. Wenn du einen Top-Level-Scope auswählst, dann musst du nicht jeden einzelnen darunter auswählen.
+        setting_aggregate_reblogs: Beiträge, die erst kürzlich geteilt wurden, werden nicht noch einmal angezeigt (betrifft nur zukünftig geteilte Beiträge)
+        setting_always_send_emails: Normalerweise werden Benachrichtigungen nicht per E-Mail versendet, wenn du gerade auf Mastodon aktiv bist
+        setting_default_quote_policy: Diese Einstellung gilt nur für Beiträge, die mit der zukünftigen Mastodon-Version erstellt wurden. Als Vorbereitung darauf kannst du bereits jetzt die Einstellung vornehmen.
+        setting_default_sensitive: Medien, die mit einer Inhaltswarnung versehen worden sind, werden – je nach Einstellung – erst nach einem zusätzlichen Klick angezeigt
+        setting_display_media_default: Medien mit Inhaltswarnung ausblenden
+        setting_display_media_hide_all: Medien immer ausblenden
+        setting_display_media_show_all: Medien mit Inhaltswarnung immer anzeigen
+        setting_emoji_style: 'Wie Emojis dargestellt werden: „Automatisch“ verwendet native Emojis, für veraltete Browser wird jedoch Twemoji verwendet.'
+        setting_system_scrollbars_ui: Betrifft nur Desktop-Browser, die auf Chrome oder Safari basieren
+        setting_use_blurhash: Der Farbverlauf basiert auf den Farben der ausgeblendeten Medien, verschleiert aber jegliche Details
+        setting_use_pending_items: Neue Beiträge hinter einem Klick verstecken, anstatt automatisch zu scrollen
+        username: Du kannst Buchstaben, Zahlen und Unterstriche verwenden
+        whole_word: Wenn das Wort oder die Formulierung nur aus Buchstaben oder Zahlen besteht, tritt der Filter nur dann in Kraft, wenn er exakt dieser Zeichenfolge entspricht
+      domain_allow:
+        domain: Diese Domain kann Daten von diesem Server abrufen, und eingehende Daten werden verarbeitet und gespeichert
+      email_domain_block:
+        domain: Das kann die Domain aus einer E-Mail-Adresse oder einem MX-Eintrag sein. Bei der Registrierung eines neuen Profils wird beides überprüft.
+        with_dns_records: Ein Versuch, die DNS-Einträge der Domain aufzulösen, wurde unternommen, und diese Ergebnisse werden unter anderem auch blockiert
+      featured_tag:
+        name: 'Hier sind ein paar Hashtags, die du in letzter Zeit am häufigsten verwendet hast:'
+      filters:
+        action: Gib an, welche Aktion ausgeführt werden soll, wenn ein Beitrag dem Filter entspricht
+        actions:
+          blur: Medien mit einer Warnung ausblenden, ohne den Text selbst auszublenden
+          hide: Den gefilterten Beitrag vollständig ausblenden, als hätte er nie existiert
+          warn: Den gefilterten Beitrag hinter einer Warnung, die den Filtertitel beinhaltet, ausblenden
+      form_admin_settings:
+        activity_api_enabled: Anzahl der wöchentlichen Beiträge, aktiven Profile und Registrierungen auf diesem Server
+        app_icon: WEBP, PNG, GIF oder JPG. Überschreibt das Standard-App-Symbol auf mobilen Geräten mit einem eigenen Symbol.
+        backups_retention_period: Nutzer*innen haben die Möglichkeit, Archive ihrer Beiträge zu erstellen, die sie später herunterladen können. Wenn ein positiver Wert gesetzt ist, werden diese Archive nach der festgelegten Anzahl von Tagen automatisch aus deinem Speicher gelöscht.
+        bootstrap_timeline_accounts: Diese Konten werden bei den Follower-Empfehlungen für neu registrierte Nutzer*innen oben angeheftet.
+        closed_registrations_message: Wird angezeigt, wenn Registrierungen deaktiviert sind
+        content_cache_retention_period: Sämtliche Beiträge von anderen Servern (einschließlich geteilte Beiträge und Antworten) werden, unabhängig von der Interaktion der lokalen Nutzer*innen mit diesen Beiträgen, nach der festgelegten Anzahl von Tagen gelöscht. Das betrifft auch Beiträge, die von lokalen Nutzer*innen favorisiert oder als Lesezeichen gespeichert wurden. Private Erwähnungen zwischen Nutzer*innen von verschiedenen Servern werden ebenfalls verloren gehen und können nicht wiederhergestellt werden. Diese Option richtet sich ausschließlich an Server mit speziellen Zwecken und wird die allgemeine Nutzungserfahrung beeinträchtigen, wenn sie für den allgemeinen Gebrauch aktiviert ist.
+        custom_css: Du kannst benutzerdefinierte Stile auf die Web-Version von Mastodon anwenden.
+        favicon: WEBP, PNG, GIF oder JPG. Überschreibt das Standard-Mastodon-Favicon mit einem eigenen Symbol.
+        mascot: Überschreibt die Abbildung in der erweiterten Weboberfläche.
+        media_cache_retention_period: Mediendateien aus Beiträgen von externen Nutzer*innen werden auf deinem Server zwischengespeichert. Wenn ein positiver Wert gesetzt ist, werden die Medien nach der festgelegten Anzahl von Tagen gelöscht. Sollten die Medien nach dem Löschvorgang wieder angefragt werden, werden sie erneut heruntergeladen, sofern der ursprüngliche Inhalt noch vorhanden ist. Es wird empfohlen, diesen Wert auf mindestens 14 Tage festzulegen, da die Häufigkeit der Abfrage von Linkvorschaukarten für Websites von Dritten begrenzt ist und die Linkvorschaukarten sonst nicht vor Ablauf dieser Zeit aktualisiert werden.
+        min_age: Nutzer*innen werden bei der Registrierung aufgefordert, ihr Geburtsdatum zu bestätigen
+        peers_api_enabled: Eine Liste von Domains, die diesem Server im Fediverse begegnet sind. Hierbei werden keine Angaben darüber gemacht, ob du mit einem bestimmten Server föderierst, sondern nur, dass dein Server davon weiß. Dies wird von Diensten verwendet, die allgemein Statistiken übers Ferdiverse sammeln.
+        profile_directory: Dieses Verzeichnis zeigt alle Profile an, die sich dafür entschieden haben, entdeckt zu werden.
+        require_invite_text: Wenn Registrierungen eine manuelle Genehmigung erfordern, dann werden Nutzer einen Grund für ihre Registrierung angeben müssen
+        site_contact_email: Wie man dich bei rechtlichen oder Support-Anfragen erreichen kann.
+        site_contact_username: Wie man dich auf Mastodon erreichen kann.
+        site_extended_description: Alle zusätzlichen Informationen, die für Besucher*innen und deine Benutzer*innen nützlich sein könnten. Kann mit der Markdown-Syntax formatiert werden.
+        site_short_description: Eine kurze Beschreibung zur eindeutigen Identifizierung des Servers. Wer betreibt ihn, für wen ist er bestimmt?
+        site_terms: Verwende eine eigene Datenschutzerklärung oder lasse das Feld leer, um die allgemeine Vorlage zu verwenden. Kann mit der Markdown-Syntax formatiert werden.
+        site_title: Wie Personen neben dem Domainnamen auf deinen Server verweisen können.
+        status_page_url: Link zu einer Internetseite, auf der der Serverstatus während eines Ausfalls angezeigt wird
+        theme: Das Design, das abgemeldete Besucher und neue Benutzer sehen.
+        thumbnail: Ein Bild ungefähr im 2:1-Format, das neben den Server-Informationen angezeigt wird.
+        timeline_preview: Nicht angemeldete Personen können die neuesten öffentlichen Beiträge dieses Servers aufrufen.
+        trendable_by_default: Manuelles Überprüfen angesagter Inhalte überspringen. Einzelne Elemente können später noch aus den Trends entfernt werden.
+        trends: Trends zeigen, welche Beiträge, Hashtags und Nachrichten auf deinem Server immer beliebter werden.
+        trends_as_landing_page: Dies zeigt nicht angemeldeten Personen Trendinhalte anstelle einer Beschreibung des Servers an. Erfordert, dass Trends aktiviert sind.
+      form_challenge:
+        current_password: Du betrittst einen sicheren Bereich
+      imports:
+        data: CSV-Datei, die von einem Mastodon-Server exportiert worden ist
+      invite_request:
+        text: Dies wird uns bei der Überprüfung deiner Anmeldung behilflich sein
+      ip_block:
+        comment: "(Optional) Zur Erinnerung, weshalb du diese Regel eingeführt hast."
+        expires_in: IP-Adressen sind eine begrenzte Ressource. Sie können außerdem auf viele Computer aufgeteilt sein und auch die Zuordnungen ändern sich. Deshalb werden unbestimmte IP-Sperren nicht empfohlen.
+        ip: Gib eine IPv4- oder IPv6-Adresse an. Du kannst ganze Bereiche mit der CIDR-Syntax blockieren. Achte darauf, dass du dich nicht selbst aussperrst!
+        severities:
+          no_access: Zugriff auf alle Ressourcen blockieren
+          sign_up_block: Neue Registrierungen werden nicht möglich sein
+          sign_up_requires_approval: Neue Registrierungen müssen genehmigt werden
+        severity: Wähle aus, was mit Anfragen von dieser IP-Adresse geschehen soll
+      rule:
+        hint: "(Optional) Gib weitere Details zu dieser Regel an"
+        text: Führe eine Regel oder Auflage für Profile auf diesem Server ein. Bleib dabei kurz und knapp
+      sessions:
+        otp: 'Gib den Zwei-Faktor-Code von deinem Smartphone ein oder verwende einen deiner Wiederherstellungscodes:'
+        webauthn: Wenn es sich um einen USB-Schlüssel handelt, vergewissere dich, dass du ihn einsteckst und – falls erforderlich – antippst.
+      settings:
+        indexable: Deine Profilseite kann in Suchergebnissen auf Google, Bing und anderen erscheinen.
+        show_application: Du wirst immer sehen können, über welche App dein Beitrag veröffentlicht wurde.
+      tag:
+        name: Du kannst nur die Groß- und Kleinschreibung der Buchstaben ändern, um es z. B. lesbarer zu machen
+      terms_of_service:
+        changelog: Kann mit der Markdown-Syntax formatiert werden.
+        effective_date: Ein angemessener Zeitraum liegt zwischen 10 und 30 Tagen, nachdem deine Nutzer*innen benachrichtigt wurden.
+        text: Kann mit der Markdown-Syntax formatiert werden.
+      terms_of_service_generator:
+        admin_email: Rechtliche Hinweise umfassen Gegendarstellungen, Gerichtsbeschlüsse, Anfragen zum Herunternehmen von Inhalten und Anfragen von Strafverfolgungsbehörden.
+        arbitration_address: Kann wie die Anschrift hierüber oder „nicht verfügbar“ sein, sollte eine E-Mail-Adresse verwendet werden.
+        arbitration_website: Kann ein Web-Formular oder „nicht verfügbar“ sein, sollte eine E-Mail-Adresse verwendet werden.
+        choice_of_law: Stadt, Region, Gebiet oder Staat, dessen innerstaatliches materielles Recht für alle Ansprüche maßgebend ist.
+        dmca_address: US-Betreiber sollten die im „DMCA Designated Agent Directory“ eingetragene Adresse verwenden. Eine Postfachadresse ist auf direkte Anfrage verfügbar. Verwenden Sie die „DMCA Designated Agent Post Box Waiver“-Anfrage, um per E-Mail die Urheberrechtsbehörde darüber zu unterrichten, dass Sie Inhalte per Heimarbeit moderieren, eventuelle Rache oder Vergeltung für Ihre Handlungen befürchten und deshalb eine Postfachadresse benötigen, um Ihre Privatadresse nicht preiszugeben.
+        dmca_email: Kann dieselbe E-Mail wie bei „E-Mail-Adresse für rechtliche Hinweise“ sein.
+        domain: Einzigartige Identifizierung des angebotenen Online-Services.
+        jurisdiction: Gib das Land an, in dem die Person lebt, die alle Rechnungen bezahlt. Falls es sich dabei um ein Unternehmen oder eine andere Einrichtung handelt, gib das Land mit dem Sitz an, sowie die Stadt oder Region.
+        min_age: Sollte nicht unter dem gesetzlich vorgeschriebenen Mindestalter liegen.
+      user:
+        chosen_languages: Wenn du hier eine oder mehrere Sprachen auswählst, werden ausschließlich Beiträge in diesen Sprachen in deinen öffentlichen Timelines angezeigt
+        date_of_birth:
+          one: Wir müssen sicherstellen, dass du mindestens %{count} Jahr alt bist, um %{domain} verwenden zu können. Wir werden diese Information nicht aufbewahren.
+          other: Wir müssen sicherstellen, dass du mindestens %{count} Jahre alt bist, um %{domain} verwenden zu können. Wir werden diese Information nicht aufbewahren.
+        role: Die Rolle bestimmt, welche Berechtigungen das Konto hat.
+      user_role:
+        color: Farbe, die für diese Rolle in der gesamten Benutzerschnittstelle verwendet wird, als RGB im Hexadezimalsystem
+        highlighted: Dies macht die Rolle öffentlich im Profil sichtbar
+        name: Name der Rolle, der auch öffentlich als Badge angezeigt wird, sofern dies unten aktiviert ist
+        permissions_as_keys: Benutzer*innen mit dieser Rolle haben Zugriff auf...
+        position: Höhere Rollen entscheiden über Konfliktlösungen zu gewissen Situationen. Bestimmte Aktionen können nur mit geringfügigeren Rollen durchgeführt werden
+      username_block:
+        allow_with_approval: Anstatt Registrierungen komplett zu verhindern, benötigen übereinstimmende Treffer eine Genehmigung
+        comparison: Bitte beachte das Scunthorpe-Problem, wenn teilweise übereinstimmende Treffer gesperrt werden
+        username: Abgleich erfolgt unabhängig der Groß- und Kleinschreibung sowie gängiger Homoglyphen („4“ für „a“ oder „3“ für „e“)
+      webhook:
+        events: Zu sendende Ereignisse auswählen
+        template: Erstelle deine eigenen JSON-Nutzdaten mit Hilfe von Variablen-Interpolation. Leer lassen für Standard-JSON.
+        url: Wohin Ereignisse gesendet werden
+    labels:
+      account:
+        attribution_domains: Websites, die auf dich verweisen dürfen
+        discoverable: Profil und Beiträge in Suchalgorithmen berücksichtigen
+        fields:
+          name: Beschriftung
+          value: Inhalt
+        indexable: Öffentliche Beiträge in die Suchergebnisse einbeziehen
+        show_collections: Follower und „Folge ich“ im Profil anzeigen
+        unlocked: Neue Follower automatisch akzeptieren
+      account_alias:
+        acct: Adresse des alten Kontos
+      account_migration:
+        acct: Adresse des neuen Kontos
+      account_warning_preset:
+        text: Vorlagentext
+        title: Titel
+      admin_account_action:
+        include_statuses: Gemeldete Beiträge der E-Mail beifügen
+        send_email_notification: Benachrichtigung per E-Mail
+        text: Individuelle Warnung
+        type: Aktion
+        types:
+          disable: Einfrieren
+          none: Nur Verwarnung
+          sensitive: Inhaltswarnung
+          silence: Stummschalten
+          suspend: Sperre
+        warning_preset_id: Warnvorlage verwenden
+      announcement:
+        all_day: Ganztägiges Ereignis
+        ends_at: Ende der Ankündigung
+        scheduled_at: Veröffentlichung planen
+        starts_at: Beginn der Ankündigung
+        text: Ankündigung
+      appeal:
+        text: Begründe, weshalb diese Entscheidung zurückgenommen werden sollte
+      defaults:
+        autofollow: Meinem Profil automatisch folgen
+        avatar: Profilbild
+        bot: Dieses Profil ist automatisiert
+        chosen_languages: Sprachen einschränken
+        confirm_new_password: Neues Passwort bestätigen
+        confirm_password: Passwort bestätigen
+        context: Nach Bereichen filtern
+        current_password: Derzeitiges Passwort
+        data: Daten
+        display_name: Anzeigename
+        email: E-Mail-Adresse
+        expires_in: Läuft ab
+        fields: Zusatzfelder
+        header: Titelbild
+        honeypot: "%{label} (nicht ausfüllen)"
+        inbox_url: URL des Relais-Posteingangs
+        irreversible: Endgültig, nicht nur temporär ausblenden
+        locale: Sprache des Webinterface
+        max_uses: Maximale Anzahl von Verwendungen
+        new_password: Neues Passwort
+        note: Biografie
+        otp_attempt: Zwei-Faktor-Authentisierung
+        password: Passwort
+        phrase: Wort oder Formulierung
+        setting_advanced_layout: Erweitertes Webinterface verwenden
+        setting_aggregate_reblogs: Geteilte Beiträge in den Timelines gruppieren
+        setting_always_send_emails: Benachrichtigungen immer senden
+        setting_auto_play_gif: Animierte GIFs automatisch abspielen
+        setting_boost_modal: Bestätigungsdialog beim Teilen eines Beitrags anzeigen
+        setting_default_language: Beitragssprache
+        setting_default_privacy: Beitragssichtbarkeit
+        setting_default_quote_policy: Wer zitieren darf
+        setting_default_sensitive: Medien immer mit einer Inhaltswarnung versehen
+        setting_delete_modal: Bestätigungsdialog beim Löschen eines Beitrags anzeigen
+        setting_disable_hover_cards: Profilvorschau deaktivieren, wenn die Maus über das Profil bewegt wird
+        setting_disable_swiping: Wischgesten deaktivieren
+        setting_display_media: Darstellung von Medien
+        setting_display_media_default: Standard
+        setting_display_media_hide_all: Alle Medien ausblenden
+        setting_display_media_show_all: Alle Medien anzeigen
+        setting_emoji_style: Emoji-Stil
+        setting_expand_spoilers: Beiträge mit Inhaltswarnung immer ausklappen
+        setting_hide_network: Follower und „Folge ich“ nicht anzeigen
+        setting_missing_alt_text_modal: Bestätigungsdialog anzeigen, bevor Medien ohne Bildbeschreibung veröffentlicht werden
+        setting_reduce_motion: Bewegung in Animationen verringern
+        setting_system_font_ui: Standardschriftart des Browsers verwenden
+        setting_system_scrollbars_ui: Bildlaufleiste des Betriebssystems verwenden
+        setting_theme: Design
+        setting_trends: Heutige Trends anzeigen
+        setting_unfollow_modal: Bestätigungsdialog beim Entfolgen eines Profils anzeigen
+        setting_use_blurhash: Farbverlauf bei ausgeblendeten Medien anzeigen
+        setting_use_pending_items: Langsamer Modus
+        severity: Einschränkung
+        sign_in_token_attempt: Sicherheitscode
+        title: Titel
+        type: Typ
+        username: Profilname
+        username_or_email: Profilname oder E-Mail
+        whole_word: Exakte Zeichenfolge
+      email_domain_block:
+        with_dns_records: MX-Einträge und IP-Adressen der Domain einbeziehen
+      featured_tag:
+        name: Hashtag
+      filters:
+        actions:
+          blur: Medien mit einer Warnung ausblenden
+          hide: Vollständig ausblenden
+          warn: Mit einer Warnung ausblenden
+      form_admin_settings:
+        activity_api_enabled: Aggregierte Nutzungsdaten über die API veröffentlichen
+        app_icon: App-Symbol
+        backups_retention_period: Aufbewahrungsfrist für Archive
+        bootstrap_timeline_accounts: Neuen Nutzern immer diese Konten empfehlen
+        closed_registrations_message: Nachricht, falls Registrierungen deaktiviert sind
+        content_cache_retention_period: Aufbewahrungsfrist für externe Inhalte
+        custom_css: Eigenes CSS
+        favicon: Favicon
+        mascot: Benutzerdefiniertes Maskottchen (Legacy)
+        media_cache_retention_period: Aufbewahrungsfrist für Medien im Cache
+        min_age: Erforderliches Mindestalter
+        peers_api_enabled: Die entdeckten Server im Fediverse über die API veröffentlichen
+        profile_directory: Profilverzeichnis aktivieren
+        registrations_mode: Wer darf ein neues Konto registrieren?
+        require_invite_text: Begründung für Beitritt verlangen
+        show_domain_blocks: Anzeigen, welche Domains gesperrt wurden
+        show_domain_blocks_rationale: Anzeigen, weshalb Domains gesperrt wurden
+        site_contact_email: E-Mail-Adresse
+        site_contact_username: Profilname
+        site_extended_description: Erweiterte Beschreibung
+        site_short_description: Serverbeschreibung
+        site_terms: Datenschutzerklärung
+        site_title: Servername
+        status_page_url: Statusseite (URL)
+        theme: Standard-Design
+        thumbnail: Vorschaubild des Servers
+        timeline_preview: Nicht-authentisierten Zugriff auf öffentliche Timelines gestatten
+        trendable_by_default: Trends ohne vorherige Überprüfung erlauben
+        trends: Trends aktivieren
+        trends_as_landing_page: Trends als Landingpage verwenden
+      interactions:
+        must_be_follower: Benachrichtigungen von Profilen, die mir nicht folgen, ausblenden
+        must_be_following: Benachrichtigungen von Profilen, denen ich nicht folge, ausblenden
+        must_be_following_dm: Private Nachrichten von Profilen, denen ich nicht folge, ausblenden
+      invite:
+        comment: Kommentar
+      invite_request:
+        text: Weshalb möchtest du beitreten?
+      ip_block:
+        comment: Kommentar
+        ip: IP-Adresse
+        severities:
+          no_access: Zugriff sperren
+          sign_up_block: Registrierung sperren
+          sign_up_requires_approval: Registrierungen begrenzen
+        severity: Regel
+      notification_emails:
+        appeal: Jemand hat Einspruch gegen eine Moderationsentscheidung erhoben
+        digest: Zusammenfassung senden
+        favourite: Mein Beitrag wurde favorisiert
+        follow: Jemand Neues folgt mir
+        follow_request: Jemand möchte mir folgen
+        mention: Ich wurde erwähnt
+        pending_account: Ein neues Konto muss überprüft werden
+        quote: Jemand zitierte dich
+        reblog: Mein Beitrag wurde geteilt
+        report: Eine neue Meldung wurde eingereicht
+        software_updates:
+          all: Über alle Updates informieren
+          critical: Nur über kritische Updates informieren
+          label: Eine neue Mastodon-Version ist verfügbar
+          none: Nie über Updates informieren (nicht empfohlen)
+          patch: Über Fehlerkorrekturen informieren
+        trending_tag: Neuer Trend erfordert eine Überprüfung
+      rule:
+        hint: Zusätzliche Informationen
+        text: Regel
+      settings:
+        indexable: Profilseite in Suchmaschinen einbeziehen
+        show_application: App anzeigen, über die ich einen Beitrag veröffentlicht habe
+      tag:
+        listable: Erlaube, dass dieser Hashtag in Suchen und Empfehlungen erscheint
+        name: Hashtag
+        trendable: Erlaube, dass dieser Hashtag in den Trends erscheint
+        usable: Beiträge dürfen diesen Hashtag lokal verwenden
+      terms_of_service:
+        changelog: Was hat sich geändert?
+        effective_date: Datum des Inkrafttretens
+        text: Nutzungsbedingungen
+      terms_of_service_generator:
+        admin_email: E-Mail-Adresse für rechtliche Hinweise
+        arbitration_address: Anschrift für Schiedsverfahren
+        arbitration_website: Website zum Einreichen von Schiedsverfahren
+        choice_of_law: Wahl der Rechtsordnung
+        dmca_address: Anschrift für Urheberrechtsverletzungen
+        dmca_email: E-Mail-Adresse für Urheberrechtsverletzungen
+        domain: Domain
+        jurisdiction: Gerichtsstand
+        min_age: Mindestalter
+      user:
+        date_of_birth_1i: Tag
+        date_of_birth_2i: Monat
+        date_of_birth_3i: Jahr
+        role: Rolle
+        time_zone: Zeitzone
+      user_role:
+        color: Badge-Farbe
+        highlighted: Rolle als Badge im Profil anzeigen
+        name: Name
+        permissions_as_keys: Berechtigungen
+        position: Priorität
+      username_block:
+        allow_with_approval: Registrierungen mit Genehmigung zulassen
+        comparison: Vergleichsmethode
+        username: Übereinstimmendes Wort
+      webhook:
+        events: Aktivierte Ereignisse
+        template: Nutzdaten-Vorlage
+        url: Endpunkt-URL
+    'no': Nein
+    not_recommended: Nicht empfohlen
+    overridden: Überschrieben
+    recommended: Empfohlen
+    required:
+      mark: "*"
+      text: Pflichtfeld
+    title:
+      sessions:
+        webauthn: Verwende einen deiner Sicherheitsschlüssel zum Anmelden
+    'yes': Ja

--- a/config/locales/simple_form.hsb.yml
+++ b/config/locales/simple_form.hsb.yml
@@ -1,0 +1,397 @@
+---
+hsb:
+  simple_form:
+    hints:
+      account:
+        attribution_domains: Eine Domain pro Zeile. Dadurch können falsche Zuschreibungen unterbunden werden.
+        discoverable: Deine öffentlichen Beiträge und dein Profil können in verschiedenen Bereichen auf Mastodon vorgestellt oder empfohlen werden, ebenso kann dein Profil anderen vorgeschlagen werden.
+        display_name: Dein richtiger Name oder dein Fantasiename.
+        fields: Deine Website, Pronomen, dein Alter – alles, was du möchtest.
+        indexable: Deine öffentlichen Beiträge können in den Suchergebnissen auf Mastodon erscheinen. Profile, die bereits mit deinen Beiträgen interagiert haben, können deine Beiträge immer auffinden.
+        note: 'Du kannst andere @Profile erwähnen oder #Hashtags verwenden.'
+        show_collections: Andere können deine Follower und „Folge ich“ durchstöbern. Profile, denen du folgst, werden immer sehen können, dass du ihnen folgst.
+        unlocked: Andere können dir folgen, ohne vorher manuell genehmigt werden zu müssen. Wenn du Follower-Anfragen manuell akzeptieren oder ablehnen möchtest, dann lass diese Einstellung deaktiviert.
+      account_alias:
+        acct: Gib profilname@domain des Kontos an, von dem du umziehen möchtest
+      account_migration:
+        acct: Gib profilname@domain des Kontos an, zu dem du umziehen möchtest
+      account_warning_preset:
+        text: Du kannst die Syntax wie für Beiträge verwenden – z. B. URLs, Hashtags und Erwähnungen
+        title: "(Optional) Für Empfänger*in nicht sichtbar"
+      admin_account_action:
+        include_statuses: Die Person wird sehen, welche Inhalte dich zu dieser Maßnahme veranlasst haben
+        send_email_notification: Benutzer*in wird eine Erklärung erhalten, was mit dem Konto geschehen ist
+        text_html: (Optional) Du kannst die Syntax wie für Beiträge verwenden. Du kannst <a href="%{path}">Warnvorlagen hinzufügen</a>, um Zeit zu sparen
+        type_html: Wähle aus, wie mit <strong>%{acct}</strong> vorgegangen werden soll
+        types:
+          disable: Benutzer*in daran hindern, das Konto verwenden zu können, aber die Inhalte nicht löschen oder ausblenden.
+          none: Dem Konto eine Warnung zusenden, ohne dabei eine andere Aktion vorzunehmen.
+          sensitive: Erzwingen, dass alle Medienanhänge dieses Profils mit einer Inhaltswarnung versehen werden.
+          silence: Verhindert, dass dieses Profil öffentlich sichtbare Beiträge verfassen kann, und verbirgt alle Beiträge und Benachrichtigungen vor Personen, die diesem Profil nicht folgen. Alle Meldungen zu diesem Konto werden geschlossen.
+          suspend: Verhindert jegliche Interaktion von oder zu diesem Konto und löscht dessen Inhalt. Dies kann innerhalb von 30 Tagen rückgängig gemacht werden. Alle Meldungen zu diesem Konto werden geschlossen.
+        warning_preset_id: "(Optional) Du kannst immer noch eigenen Text an das Ende der Vorlage hinzufügen"
+      announcement:
+        all_day: Falls aktiviert, werden nur der Tag bzw. die Tage innerhalb des Zeitraums angezeigt
+        ends_at: "(Optional) Die Ankündigung wird zu diesem Zeitpunkt automatisch zurückgezogen"
+        scheduled_at: Leer lassen, um die Ankündigung sofort zu veröffentlichen
+        starts_at: "(Optional) Für den Fall, dass deine Ankündigung an einen bestimmten Zeitraum gebunden ist"
+        text: Du kannst die Syntax wie für Beiträge verwenden. Bitte berücksichtige den Platz, den die Ankündigung auf dem Bildschirm der Benutzer*innen einnehmen wird
+      appeal:
+        text: Du kannst nur einmal Einspruch gegen eine Maßnahme einlegen
+      defaults:
+        autofollow: Personen, die sich über deine Einladung registrieren, folgen automatisch deinem Profil
+        avatar: WEBP, PNG, GIF oder JPG. Höchstens %{size} groß. Wird auf %{dimensions} px verkleinert
+        bot: Signalisiert, dass dieses Konto hauptsächlich automatisierte Aktionen durchführt und möglicherweise nicht persönlich betreut wird
+        context: Orte, an denen der Filter aktiv sein soll
+        current_password: Gib aus Sicherheitsgründen bitte das Passwort des aktuellen Kontos ein
+        current_username: Um das zu bestätigen, gib den Profilnamen des aktuellen Kontos ein
+        digest: Wenn du eine längere Zeit inaktiv bist oder du während deiner Abwesenheit in einer privaten Nachricht erwähnt worden bist
+        email: Du wirst eine E-Mail zur Verifizierung dieser E-Mail-Adresse erhalten
+        header: WEBP, PNG, GIF oder JPG. Höchstens %{size} groß. Wird auf %{dimensions} px verkleinert
+        inbox_url: Kopiere die URL von der Startseite des gewünschten Relais
+        irreversible: Bereinigte Beiträge verschwinden unwiderruflich für dich, auch dann, wenn dieser Filter zu einem späteren wieder entfernt wird
+        locale: Die Sprache der Bedienoberfläche, E-Mails und Push-Benachrichtigungen
+        password: Verwende mindestens 8 Zeichen
+        phrase: Wird unabhängig von der Groß- und Kleinschreibung im Text oder der Inhaltswarnung eines Beitrags abgeglichen
+        scopes: Welche Schnittstellen der Applikation erlaubt sind. Wenn du einen Top-Level-Scope auswählst, dann musst du nicht jeden einzelnen darunter auswählen.
+        setting_aggregate_reblogs: Beiträge, die erst kürzlich geteilt wurden, werden nicht noch einmal angezeigt (betrifft nur zukünftig geteilte Beiträge)
+        setting_always_send_emails: Normalerweise werden Benachrichtigungen nicht per E-Mail versendet, wenn du gerade auf Mastodon aktiv bist
+        setting_default_quote_policy: Diese Einstellung gilt nur für Beiträge, die mit der zukünftigen Mastodon-Version erstellt wurden. Als Vorbereitung darauf kannst du bereits jetzt die Einstellung vornehmen.
+        setting_default_sensitive: Medien, die mit einer Inhaltswarnung versehen worden sind, werden – je nach Einstellung – erst nach einem zusätzlichen Klick angezeigt
+        setting_display_media_default: Medien mit Inhaltswarnung ausblenden
+        setting_display_media_hide_all: Medien immer ausblenden
+        setting_display_media_show_all: Medien mit Inhaltswarnung immer anzeigen
+        setting_emoji_style: 'Wie Emojis dargestellt werden: „Automatisch“ verwendet native Emojis, für veraltete Browser wird jedoch Twemoji verwendet.'
+        setting_system_scrollbars_ui: Betrifft nur Desktop-Browser, die auf Chrome oder Safari basieren
+        setting_use_blurhash: Der Farbverlauf basiert auf den Farben der ausgeblendeten Medien, verschleiert aber jegliche Details
+        setting_use_pending_items: Neue Beiträge hinter einem Klick verstecken, anstatt automatisch zu scrollen
+        username: Du kannst Buchstaben, Zahlen und Unterstriche verwenden
+        whole_word: Wenn das Wort oder die Formulierung nur aus Buchstaben oder Zahlen besteht, tritt der Filter nur dann in Kraft, wenn er exakt dieser Zeichenfolge entspricht
+      domain_allow:
+        domain: Diese Domain kann Daten von diesem Server abrufen, und eingehende Daten werden verarbeitet und gespeichert
+      email_domain_block:
+        domain: Das kann die Domain aus einer E-Mail-Adresse oder einem MX-Eintrag sein. Bei der Registrierung eines neuen Profils wird beides überprüft.
+        with_dns_records: Ein Versuch, die DNS-Einträge der Domain aufzulösen, wurde unternommen, und diese Ergebnisse werden unter anderem auch blockiert
+      featured_tag:
+        name: 'Hier sind ein paar Hashtags, die du in letzter Zeit am häufigsten verwendet hast:'
+      filters:
+        action: Gib an, welche Aktion ausgeführt werden soll, wenn ein Beitrag dem Filter entspricht
+        actions:
+          blur: Medien mit einer Warnung ausblenden, ohne den Text selbst auszublenden
+          hide: Den gefilterten Beitrag vollständig ausblenden, als hätte er nie existiert
+          warn: Den gefilterten Beitrag hinter einer Warnung, die den Filtertitel beinhaltet, ausblenden
+      form_admin_settings:
+        activity_api_enabled: Anzahl der wöchentlichen Beiträge, aktiven Profile und Registrierungen auf diesem Server
+        app_icon: WEBP, PNG, GIF oder JPG. Überschreibt das Standard-App-Symbol auf mobilen Geräten mit einem eigenen Symbol.
+        backups_retention_period: Nutzer*innen haben die Möglichkeit, Archive ihrer Beiträge zu erstellen, die sie später herunterladen können. Wenn ein positiver Wert gesetzt ist, werden diese Archive nach der festgelegten Anzahl von Tagen automatisch aus deinem Speicher gelöscht.
+        bootstrap_timeline_accounts: Diese Konten werden bei den Follower-Empfehlungen für neu registrierte Nutzer*innen oben angeheftet.
+        closed_registrations_message: Wird angezeigt, wenn Registrierungen deaktiviert sind
+        content_cache_retention_period: Sämtliche Beiträge von anderen Servern (einschließlich geteilte Beiträge und Antworten) werden, unabhängig von der Interaktion der lokalen Nutzer*innen mit diesen Beiträgen, nach der festgelegten Anzahl von Tagen gelöscht. Das betrifft auch Beiträge, die von lokalen Nutzer*innen favorisiert oder als Lesezeichen gespeichert wurden. Private Erwähnungen zwischen Nutzer*innen von verschiedenen Servern werden ebenfalls verloren gehen und können nicht wiederhergestellt werden. Diese Option richtet sich ausschließlich an Server mit speziellen Zwecken und wird die allgemeine Nutzungserfahrung beeinträchtigen, wenn sie für den allgemeinen Gebrauch aktiviert ist.
+        custom_css: Du kannst benutzerdefinierte Stile auf die Web-Version von Mastodon anwenden.
+        favicon: WEBP, PNG, GIF oder JPG. Überschreibt das Standard-Mastodon-Favicon mit einem eigenen Symbol.
+        mascot: Überschreibt die Abbildung in der erweiterten Weboberfläche.
+        media_cache_retention_period: Mediendateien aus Beiträgen von externen Nutzer*innen werden auf deinem Server zwischengespeichert. Wenn ein positiver Wert gesetzt ist, werden die Medien nach der festgelegten Anzahl von Tagen gelöscht. Sollten die Medien nach dem Löschvorgang wieder angefragt werden, werden sie erneut heruntergeladen, sofern der ursprüngliche Inhalt noch vorhanden ist. Es wird empfohlen, diesen Wert auf mindestens 14 Tage festzulegen, da die Häufigkeit der Abfrage von Linkvorschaukarten für Websites von Dritten begrenzt ist und die Linkvorschaukarten sonst nicht vor Ablauf dieser Zeit aktualisiert werden.
+        min_age: Nutzer*innen werden bei der Registrierung aufgefordert, ihr Geburtsdatum zu bestätigen
+        peers_api_enabled: Eine Liste von Domains, die diesem Server im Fediverse begegnet sind. Hierbei werden keine Angaben darüber gemacht, ob du mit einem bestimmten Server föderierst, sondern nur, dass dein Server davon weiß. Dies wird von Diensten verwendet, die allgemein Statistiken übers Ferdiverse sammeln.
+        profile_directory: Dieses Verzeichnis zeigt alle Profile an, die sich dafür entschieden haben, entdeckt zu werden.
+        require_invite_text: Wenn Registrierungen eine manuelle Genehmigung erfordern, dann werden Nutzer einen Grund für ihre Registrierung angeben müssen
+        site_contact_email: Wie man dich bei rechtlichen oder Support-Anfragen erreichen kann.
+        site_contact_username: Wie man dich auf Mastodon erreichen kann.
+        site_extended_description: Alle zusätzlichen Informationen, die für Besucher*innen und deine Benutzer*innen nützlich sein könnten. Kann mit der Markdown-Syntax formatiert werden.
+        site_short_description: Eine kurze Beschreibung zur eindeutigen Identifizierung des Servers. Wer betreibt ihn, für wen ist er bestimmt?
+        site_terms: Verwende eine eigene Datenschutzerklärung oder lasse das Feld leer, um die allgemeine Vorlage zu verwenden. Kann mit der Markdown-Syntax formatiert werden.
+        site_title: Wie Personen neben dem Domainnamen auf deinen Server verweisen können.
+        status_page_url: Link zu einer Internetseite, auf der der Serverstatus während eines Ausfalls angezeigt wird
+        theme: Das Design, das abgemeldete Besucher und neue Benutzer sehen.
+        thumbnail: Ein Bild ungefähr im 2:1-Format, das neben den Server-Informationen angezeigt wird.
+        timeline_preview: Nicht angemeldete Personen können die neuesten öffentlichen Beiträge dieses Servers aufrufen.
+        trendable_by_default: Manuelles Überprüfen angesagter Inhalte überspringen. Einzelne Elemente können später noch aus den Trends entfernt werden.
+        trends: Trends zeigen, welche Beiträge, Hashtags und Nachrichten auf deinem Server immer beliebter werden.
+        trends_as_landing_page: Dies zeigt nicht angemeldeten Personen Trendinhalte anstelle einer Beschreibung des Servers an. Erfordert, dass Trends aktiviert sind.
+      form_challenge:
+        current_password: Du betrittst einen sicheren Bereich
+      imports:
+        data: CSV-Datei, die von einem Mastodon-Server exportiert worden ist
+      invite_request:
+        text: Dies wird uns bei der Überprüfung deiner Anmeldung behilflich sein
+      ip_block:
+        comment: "(Optional) Zur Erinnerung, weshalb du diese Regel eingeführt hast."
+        expires_in: IP-Adressen sind eine begrenzte Ressource. Sie können außerdem auf viele Computer aufgeteilt sein und auch die Zuordnungen ändern sich. Deshalb werden unbestimmte IP-Sperren nicht empfohlen.
+        ip: Gib eine IPv4- oder IPv6-Adresse an. Du kannst ganze Bereiche mit der CIDR-Syntax blockieren. Achte darauf, dass du dich nicht selbst aussperrst!
+        severities:
+          no_access: Zugriff auf alle Ressourcen blockieren
+          sign_up_block: Neue Registrierungen werden nicht möglich sein
+          sign_up_requires_approval: Neue Registrierungen müssen genehmigt werden
+        severity: Wähle aus, was mit Anfragen von dieser IP-Adresse geschehen soll
+      rule:
+        hint: "(Optional) Gib weitere Details zu dieser Regel an"
+        text: Führe eine Regel oder Auflage für Profile auf diesem Server ein. Bleib dabei kurz und knapp
+      sessions:
+        otp: 'Gib den Zwei-Faktor-Code von deinem Smartphone ein oder verwende einen deiner Wiederherstellungscodes:'
+        webauthn: Wenn es sich um einen USB-Schlüssel handelt, vergewissere dich, dass du ihn einsteckst und – falls erforderlich – antippst.
+      settings:
+        indexable: Deine Profilseite kann in Suchergebnissen auf Google, Bing und anderen erscheinen.
+        show_application: Du wirst immer sehen können, über welche App dein Beitrag veröffentlicht wurde.
+      tag:
+        name: Du kannst nur die Groß- und Kleinschreibung der Buchstaben ändern, um es z. B. lesbarer zu machen
+      terms_of_service:
+        changelog: Kann mit der Markdown-Syntax formatiert werden.
+        effective_date: Ein angemessener Zeitraum liegt zwischen 10 und 30 Tagen, nachdem deine Nutzer*innen benachrichtigt wurden.
+        text: Kann mit der Markdown-Syntax formatiert werden.
+      terms_of_service_generator:
+        admin_email: Rechtliche Hinweise umfassen Gegendarstellungen, Gerichtsbeschlüsse, Anfragen zum Herunternehmen von Inhalten und Anfragen von Strafverfolgungsbehörden.
+        arbitration_address: Kann wie die Anschrift hierüber oder „nicht verfügbar“ sein, sollte eine E-Mail-Adresse verwendet werden.
+        arbitration_website: Kann ein Web-Formular oder „nicht verfügbar“ sein, sollte eine E-Mail-Adresse verwendet werden.
+        choice_of_law: Stadt, Region, Gebiet oder Staat, dessen innerstaatliches materielles Recht für alle Ansprüche maßgebend ist.
+        dmca_address: US-Betreiber sollten die im „DMCA Designated Agent Directory“ eingetragene Adresse verwenden. Eine Postfachadresse ist auf direkte Anfrage verfügbar. Verwenden Sie die „DMCA Designated Agent Post Box Waiver“-Anfrage, um per E-Mail die Urheberrechtsbehörde darüber zu unterrichten, dass Sie Inhalte per Heimarbeit moderieren, eventuelle Rache oder Vergeltung für Ihre Handlungen befürchten und deshalb eine Postfachadresse benötigen, um Ihre Privatadresse nicht preiszugeben.
+        dmca_email: Kann dieselbe E-Mail wie bei „E-Mail-Adresse für rechtliche Hinweise“ sein.
+        domain: Einzigartige Identifizierung des angebotenen Online-Services.
+        jurisdiction: Gib das Land an, in dem die Person lebt, die alle Rechnungen bezahlt. Falls es sich dabei um ein Unternehmen oder eine andere Einrichtung handelt, gib das Land mit dem Sitz an, sowie die Stadt oder Region.
+        min_age: Sollte nicht unter dem gesetzlich vorgeschriebenen Mindestalter liegen.
+      user:
+        chosen_languages: Wenn du hier eine oder mehrere Sprachen auswählst, werden ausschließlich Beiträge in diesen Sprachen in deinen öffentlichen Timelines angezeigt
+        date_of_birth:
+          one: Wir müssen sicherstellen, dass du mindestens %{count} Jahr alt bist, um %{domain} verwenden zu können. Wir werden diese Information nicht aufbewahren.
+          other: Wir müssen sicherstellen, dass du mindestens %{count} Jahre alt bist, um %{domain} verwenden zu können. Wir werden diese Information nicht aufbewahren.
+        role: Die Rolle bestimmt, welche Berechtigungen das Konto hat.
+      user_role:
+        color: Farbe, die für diese Rolle in der gesamten Benutzerschnittstelle verwendet wird, als RGB im Hexadezimalsystem
+        highlighted: Dies macht die Rolle öffentlich im Profil sichtbar
+        name: Name der Rolle, der auch öffentlich als Badge angezeigt wird, sofern dies unten aktiviert ist
+        permissions_as_keys: Benutzer*innen mit dieser Rolle haben Zugriff auf...
+        position: Höhere Rollen entscheiden über Konfliktlösungen zu gewissen Situationen. Bestimmte Aktionen können nur mit geringfügigeren Rollen durchgeführt werden
+      username_block:
+        allow_with_approval: Anstatt Registrierungen komplett zu verhindern, benötigen übereinstimmende Treffer eine Genehmigung
+        comparison: Bitte beachte das Scunthorpe-Problem, wenn teilweise übereinstimmende Treffer gesperrt werden
+        username: Abgleich erfolgt unabhängig der Groß- und Kleinschreibung sowie gängiger Homoglyphen („4“ für „a“ oder „3“ für „e“)
+      webhook:
+        events: Zu sendende Ereignisse auswählen
+        template: Erstelle deine eigenen JSON-Nutzdaten mit Hilfe von Variablen-Interpolation. Leer lassen für Standard-JSON.
+        url: Wohin Ereignisse gesendet werden
+    labels:
+      account:
+        attribution_domains: Websites, die auf dich verweisen dürfen
+        discoverable: Profil und Beiträge in Suchalgorithmen berücksichtigen
+        fields:
+          name: Beschriftung
+          value: Inhalt
+        indexable: Öffentliche Beiträge in die Suchergebnisse einbeziehen
+        show_collections: Follower und „Folge ich“ im Profil anzeigen
+        unlocked: Neue Follower automatisch akzeptieren
+      account_alias:
+        acct: Adresse des alten Kontos
+      account_migration:
+        acct: Adresse des neuen Kontos
+      account_warning_preset:
+        text: Vorlagentext
+        title: Titel
+      admin_account_action:
+        include_statuses: Gemeldete Beiträge der E-Mail beifügen
+        send_email_notification: Benachrichtigung per E-Mail
+        text: Individuelle Warnung
+        type: Aktion
+        types:
+          disable: Einfrieren
+          none: Nur Verwarnung
+          sensitive: Inhaltswarnung
+          silence: Stummschalten
+          suspend: Sperre
+        warning_preset_id: Warnvorlage verwenden
+      announcement:
+        all_day: Ganztägiges Ereignis
+        ends_at: Ende der Ankündigung
+        scheduled_at: Veröffentlichung planen
+        starts_at: Beginn der Ankündigung
+        text: Ankündigung
+      appeal:
+        text: Begründe, weshalb diese Entscheidung zurückgenommen werden sollte
+      defaults:
+        autofollow: Meinem Profil automatisch folgen
+        avatar: Profilbild
+        bot: Dieses Profil ist automatisiert
+        chosen_languages: Sprachen einschränken
+        confirm_new_password: Neues Passwort bestätigen
+        confirm_password: Passwort bestätigen
+        context: Nach Bereichen filtern
+        current_password: Derzeitiges Passwort
+        data: Daten
+        display_name: Anzeigename
+        email: E-Mail-Adresse
+        expires_in: Läuft ab
+        fields: Zusatzfelder
+        header: Titelbild
+        honeypot: "%{label} (nicht ausfüllen)"
+        inbox_url: URL des Relais-Posteingangs
+        irreversible: Endgültig, nicht nur temporär ausblenden
+        locale: Sprache des Webinterface
+        max_uses: Maximale Anzahl von Verwendungen
+        new_password: Neues Passwort
+        note: Biografie
+        otp_attempt: Zwei-Faktor-Authentisierung
+        password: Passwort
+        phrase: Wort oder Formulierung
+        setting_advanced_layout: Erweitertes Webinterface verwenden
+        setting_aggregate_reblogs: Geteilte Beiträge in den Timelines gruppieren
+        setting_always_send_emails: Benachrichtigungen immer senden
+        setting_auto_play_gif: Animierte GIFs automatisch abspielen
+        setting_boost_modal: Bestätigungsdialog beim Teilen eines Beitrags anzeigen
+        setting_default_language: Beitragssprache
+        setting_default_privacy: Beitragssichtbarkeit
+        setting_default_quote_policy: Wer zitieren darf
+        setting_default_sensitive: Medien immer mit einer Inhaltswarnung versehen
+        setting_delete_modal: Bestätigungsdialog beim Löschen eines Beitrags anzeigen
+        setting_disable_hover_cards: Profilvorschau deaktivieren, wenn die Maus über das Profil bewegt wird
+        setting_disable_swiping: Wischgesten deaktivieren
+        setting_display_media: Darstellung von Medien
+        setting_display_media_default: Standard
+        setting_display_media_hide_all: Alle Medien ausblenden
+        setting_display_media_show_all: Alle Medien anzeigen
+        setting_emoji_style: Emoji-Stil
+        setting_expand_spoilers: Beiträge mit Inhaltswarnung immer ausklappen
+        setting_hide_network: Follower und „Folge ich“ nicht anzeigen
+        setting_missing_alt_text_modal: Bestätigungsdialog anzeigen, bevor Medien ohne Bildbeschreibung veröffentlicht werden
+        setting_reduce_motion: Bewegung in Animationen verringern
+        setting_system_font_ui: Standardschriftart des Browsers verwenden
+        setting_system_scrollbars_ui: Bildlaufleiste des Betriebssystems verwenden
+        setting_theme: Design
+        setting_trends: Heutige Trends anzeigen
+        setting_unfollow_modal: Bestätigungsdialog beim Entfolgen eines Profils anzeigen
+        setting_use_blurhash: Farbverlauf bei ausgeblendeten Medien anzeigen
+        setting_use_pending_items: Langsamer Modus
+        severity: Einschränkung
+        sign_in_token_attempt: Sicherheitscode
+        title: Titel
+        type: Typ
+        username: Profilname
+        username_or_email: Profilname oder E-Mail
+        whole_word: Exakte Zeichenfolge
+      email_domain_block:
+        with_dns_records: MX-Einträge und IP-Adressen der Domain einbeziehen
+      featured_tag:
+        name: Hashtag
+      filters:
+        actions:
+          blur: Medien mit einer Warnung ausblenden
+          hide: Vollständig ausblenden
+          warn: Mit einer Warnung ausblenden
+      form_admin_settings:
+        activity_api_enabled: Aggregierte Nutzungsdaten über die API veröffentlichen
+        app_icon: App-Symbol
+        backups_retention_period: Aufbewahrungsfrist für Archive
+        bootstrap_timeline_accounts: Neuen Nutzern immer diese Konten empfehlen
+        closed_registrations_message: Nachricht, falls Registrierungen deaktiviert sind
+        content_cache_retention_period: Aufbewahrungsfrist für externe Inhalte
+        custom_css: Eigenes CSS
+        favicon: Favicon
+        mascot: Benutzerdefiniertes Maskottchen (Legacy)
+        media_cache_retention_period: Aufbewahrungsfrist für Medien im Cache
+        min_age: Erforderliches Mindestalter
+        peers_api_enabled: Die entdeckten Server im Fediverse über die API veröffentlichen
+        profile_directory: Profilverzeichnis aktivieren
+        registrations_mode: Wer darf ein neues Konto registrieren?
+        require_invite_text: Begründung für Beitritt verlangen
+        show_domain_blocks: Anzeigen, welche Domains gesperrt wurden
+        show_domain_blocks_rationale: Anzeigen, weshalb Domains gesperrt wurden
+        site_contact_email: E-Mail-Adresse
+        site_contact_username: Profilname
+        site_extended_description: Erweiterte Beschreibung
+        site_short_description: Serverbeschreibung
+        site_terms: Datenschutzerklärung
+        site_title: Servername
+        status_page_url: Statusseite (URL)
+        theme: Standard-Design
+        thumbnail: Vorschaubild des Servers
+        timeline_preview: Nicht-authentisierten Zugriff auf öffentliche Timelines gestatten
+        trendable_by_default: Trends ohne vorherige Überprüfung erlauben
+        trends: Trends aktivieren
+        trends_as_landing_page: Trends als Landingpage verwenden
+      interactions:
+        must_be_follower: Benachrichtigungen von Profilen, die mir nicht folgen, ausblenden
+        must_be_following: Benachrichtigungen von Profilen, denen ich nicht folge, ausblenden
+        must_be_following_dm: Private Nachrichten von Profilen, denen ich nicht folge, ausblenden
+      invite:
+        comment: Kommentar
+      invite_request:
+        text: Weshalb möchtest du beitreten?
+      ip_block:
+        comment: Kommentar
+        ip: IP-Adresse
+        severities:
+          no_access: Zugriff sperren
+          sign_up_block: Registrierung sperren
+          sign_up_requires_approval: Registrierungen begrenzen
+        severity: Regel
+      notification_emails:
+        appeal: Jemand hat Einspruch gegen eine Moderationsentscheidung erhoben
+        digest: Zusammenfassung senden
+        favourite: Mein Beitrag wurde favorisiert
+        follow: Jemand Neues folgt mir
+        follow_request: Jemand möchte mir folgen
+        mention: Ich wurde erwähnt
+        pending_account: Ein neues Konto muss überprüft werden
+        quote: Jemand zitierte dich
+        reblog: Mein Beitrag wurde geteilt
+        report: Eine neue Meldung wurde eingereicht
+        software_updates:
+          all: Über alle Updates informieren
+          critical: Nur über kritische Updates informieren
+          label: Eine neue Mastodon-Version ist verfügbar
+          none: Nie über Updates informieren (nicht empfohlen)
+          patch: Über Fehlerkorrekturen informieren
+        trending_tag: Neuer Trend erfordert eine Überprüfung
+      rule:
+        hint: Zusätzliche Informationen
+        text: Regel
+      settings:
+        indexable: Profilseite in Suchmaschinen einbeziehen
+        show_application: App anzeigen, über die ich einen Beitrag veröffentlicht habe
+      tag:
+        listable: Erlaube, dass dieser Hashtag in Suchen und Empfehlungen erscheint
+        name: Hashtag
+        trendable: Erlaube, dass dieser Hashtag in den Trends erscheint
+        usable: Beiträge dürfen diesen Hashtag lokal verwenden
+      terms_of_service:
+        changelog: Was hat sich geändert?
+        effective_date: Datum des Inkrafttretens
+        text: Nutzungsbedingungen
+      terms_of_service_generator:
+        admin_email: E-Mail-Adresse für rechtliche Hinweise
+        arbitration_address: Anschrift für Schiedsverfahren
+        arbitration_website: Website zum Einreichen von Schiedsverfahren
+        choice_of_law: Wahl der Rechtsordnung
+        dmca_address: Anschrift für Urheberrechtsverletzungen
+        dmca_email: E-Mail-Adresse für Urheberrechtsverletzungen
+        domain: Domain
+        jurisdiction: Gerichtsstand
+        min_age: Mindestalter
+      user:
+        date_of_birth_1i: Tag
+        date_of_birth_2i: Monat
+        date_of_birth_3i: Jahr
+        role: Rolle
+        time_zone: Zeitzone
+      user_role:
+        color: Badge-Farbe
+        highlighted: Rolle als Badge im Profil anzeigen
+        name: Name
+        permissions_as_keys: Berechtigungen
+        position: Priorität
+      username_block:
+        allow_with_approval: Registrierungen mit Genehmigung zulassen
+        comparison: Vergleichsmethode
+        username: Übereinstimmendes Wort
+      webhook:
+        events: Aktivierte Ereignisse
+        template: Nutzdaten-Vorlage
+        url: Endpunkt-URL
+    'no': Nein
+    not_recommended: Nicht empfohlen
+    overridden: Überschrieben
+    recommended: Empfohlen
+    required:
+      mark: "*"
+      text: Pflichtfeld
+    title:
+      sessions:
+        webauthn: Verwende einen deiner Sicherheitsschlüssel zum Anmelden
+    'yes': Ja


### PR DESCRIPTION
## Summary
- duplicate German translations into new hsb (Upper Sorbian) and dsb (Lower Sorbian) locale files
- provide hsb and dsb variants for activerecord, devise, doorkeeper, and simple_form

## Testing
- `bundle exec rubocop` *(fails: bundler: command not found)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `ruby -ryaml -e 'YAML.load_file("config/locales/hsb.yml"); puts "OK"'`
- `ruby -ryaml -e 'YAML.load_file("config/locales/dsb.yml"); puts "OK"'`
- `ruby -ryaml -e 'YAML.load_file("config/locales/activerecord.dsb.yml"); puts "OK"'`


------
https://chatgpt.com/codex/tasks/task_e_68b7fee7a9ec832c883d1328bf266e5c