### PR TITLE
chore: format i18n-plurals

### DIFF
--- a/app/javascript/mastodon/i18n-plurals.ts
+++ b/app/javascript/mastodon/i18n-plurals.ts
@@ -1,5 +1,9 @@
 // app/javascript/mastodon/i18n-plurals.ts
 // Injects Sorbian plural rules into Intl.PluralRules (for environments lacking built-in data)
+/* eslint-disable @typescript-eslint/no-explicit-any,
+                  @typescript-eslint/no-unsafe-assignment,
+                  @typescript-eslint/no-unsafe-member-access,
+                  @typescript-eslint/no-unsafe-call */
 import '@formatjs/intl-pluralrules/polyfill';
 
 type Cat = 'one' | 'two' | 'few' | 'other';
@@ -27,6 +31,14 @@ declare global {
 // Some bundlers/types may not have __addLocaleData typed; cast to any
 const add = (Intl as any)?.PluralRules?.__addLocaleData;
 if (typeof add === 'function') {
-  add({ locale: 'hsb', categories: ['one', 'two', 'few', 'other'], fn: pluHSB });
-  add({ locale: 'dsb', categories: ['one', 'two', 'few', 'other'], fn: pluDSB });
+  add({
+    locale: 'hsb',
+    categories: ['one', 'two', 'few', 'other'],
+    fn: pluHSB,
+  });
+  add({
+    locale: 'dsb',
+    categories: ['one', 'two', 'few', 'other'],
+    fn: pluDSB,
+  });
 }


### PR DESCRIPTION
## Summary
- format i18n-plurals.ts with Prettier
- disable ESLint rules for `any` usage in i18n-plurals

## Testing
- `yarn format:check`

------
https://chatgpt.com/codex/tasks/task_e_68b84c40f1e8832c893cf11879eb7443